### PR TITLE
Quote value to fix template error

### DIFF
--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -258,7 +258,7 @@ runMigrations: true
 env:
   # Giant Swarm: Disable database by default to avoid needing to manage
   # Postgres. State is stored in Ingress resources.
-  database: off
+  database: "off"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout
   admin_gui_access_log: /dev/stdout


### PR DESCRIPTION
Disabling the database needs to be quoted because the value is compared in the templates.

https://github.com/giantswarm/kong-app/blob/db63a69ec7a19fb784821a5f145eed329c0f3c35/helm/kong-app/templates/migrations.yaml#L1