### PR TITLE
Retag images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.2.0] WIP
+
+### Updated
+
+- Use retagged images.
+
 ## [v0.1.0]
 
 ### Added

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -8,4 +8,4 @@ name: kong-app
 sources:
 - https://github.com/Kong/kong
 version: [[ .Version ]]
-appVersion: 1.2
+appVersion: 1.2.2

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Create the ingress servicePort value string
 
 {{- define "kong.wait-for-db" -}}
 - name: wait-for-db
-  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   env:
   {{- if .Values.enterprise.enabled }}

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -185,7 +185,7 @@ Create the ingress servicePort value string
       fieldRef:
         apiVersion: v1
         fieldPath: metadata.namespace
-  image: "{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
+  image: "{{ .Values.image.registry }}/{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   livenessProbe:
     failureThreshold: 3

--- a/helm/kong-app/templates/controller-deployment.yaml
+++ b/helm/kong-app/templates/controller-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- include "kong.wait-for-db" . | nindent 6 }}
       containers:
       - name: admin-api
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KONG_PROXY_LISTEN

--- a/helm/kong-app/templates/deployment.yaml
+++ b/helm/kong-app/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
       - name: {{ template "kong.name" . }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- if not .Values.env.admin_listen }}

--- a/helm/kong-app/templates/migrations-post-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-post-upgrade.yaml
@@ -32,7 +32,7 @@ spec:
       {{- if .Values.postgresql.enabled }}
       initContainers:
       - name: wait-for-postgres
-        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}

--- a/helm/kong-app/templates/migrations-post-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-post-upgrade.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KONG_NGINX_DAEMON

--- a/helm/kong-app/templates/migrations-pre-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-pre-upgrade.yaml
@@ -32,7 +32,7 @@ spec:
       {{- if .Values.postgresql.enabled }}
       initContainers:
       - name: wait-for-postgres
-        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}

--- a/helm/kong-app/templates/migrations-pre-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-pre-upgrade.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KONG_NGINX_DAEMON

--- a/helm/kong-app/templates/migrations.yaml
+++ b/helm/kong-app/templates/migrations.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KONG_NGINX_DAEMON

--- a/helm/kong-app/templates/migrations.yaml
+++ b/helm/kong-app/templates/migrations.yaml
@@ -27,7 +27,7 @@ spec:
       {{- if .Values.postgresql.enabled }}
       initContainers:
       - name: wait-for-postgres
-        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -2,8 +2,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: kong
-  # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+  registry: quay.io
+  repository: giantswarm/kong
   tag: 1.2
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: quay.io
   repository: giantswarm/kong
-  tag: 1.2
+  tag: 1.2.2
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -353,7 +353,7 @@ ingressController:
   # Giant Swarm: Enable ingress controller mode by default.
   enabled: true
   image:
-    repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
+    repository: giantswarm/kong-ingress-controller
     tag: 0.5.0
   replicaCount: 1
   livenessProbe:

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -15,8 +15,8 @@ image:
   #   - myRegistrKeySecretName
 
 waitImage:
-  repository: busybox
-  tag: latest
+  repository: giantswarm/busybox
+  tag: 1.31.0
 
 # Specify Kong admin and proxy services configurations
 admin:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6712

Retags the `kong` and `kong-ingress-controller` images and uses our `busybox` image as the wait image.