### PR TITLE
Remove node ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Updated
 
 - Use retagged images.
+- Use ClusterIP for all services except proxy which uses LoadBalancer.
 
 ## [v0.1.0]
 

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -31,7 +31,7 @@ admin:
   servicePort: 8444
   containerPort: 8444
   # Kong admin service type
-  type: NodePort
+  type: ClusterIP
   # Set a nodePort which is available
   # nodePort: 32444
   # Kong admin ingress settings.
@@ -108,7 +108,7 @@ manager:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
 
-  type: NodePort
+  type: ClusterIP
 
   # Kong proxy ingress settings.
   ingress:
@@ -146,7 +146,7 @@ portal:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
 
-  type: NodePort
+  type: ClusterIP
 
   # Kong proxy ingress settings.
   ingress:
@@ -184,7 +184,7 @@ portalapi:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
 
-  type: NodePort
+  type: ClusterIP
 
   # Kong proxy ingress settings.
   ingress:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6712

Fixes the values for all services except proxy to use ClusterIP. The NodePort default doesn't make sense for us.

The proxy service remains as a LoadBalancer service for inbound traffic.