### PR TITLE
Add support for the validation controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.4.0] 
+
+### Added
+
+- Add support for validation controller as optional.
+
 ## [v0.3.0] 
 
 ### Updated

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -270,6 +270,16 @@ Create the ingress servicePort value string
         fieldPath: metadata.namespace
   image: "{{ .Values.image.registry }}/{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
   imagePullPolicy: {{ .Values.image.pullPolicy }}
+  {{- if .Values.ingressController.validationController.enabled }}
+  ports:
+  - name: webhook
+    containerPort: 8080
+    protocol: TCP
+  volumeMounts:
+  - name: validation-webhook
+    mountPath: /admission-webhook
+    readOnly: true
+  {{- end }}
   readinessProbe:
 {{ toYaml .Values.ingressController.readinessProbe | indent 4 }}
   livenessProbe:

--- a/helm/kong-app/templates/deployment.yaml
+++ b/helm/kong-app/templates/deployment.yaml
@@ -280,4 +280,9 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       volumes:
-      {{- include "kong.volumes" . | nindent 8 -}}
+      {{- if .Values.ingressController.validationController.enabled }}
+      - name: validation-webhook
+        secret:
+          secretName: {{ template "kong.fullname" . }}-validation
+      {{- end }}
+      {{- include "kong.volumes" . | nindent 6 -}}

--- a/helm/kong-app/templates/service-kong-validation.yaml
+++ b/helm/kong-app/templates/service-kong-validation.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingressController.validationController.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-validation
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  ports:
+  - name: webhook
+    port: 443
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}
+    component: app
+{{- end }}

--- a/helm/kong-app/templates/validation-webhook-configuration.yaml
+++ b/helm/kong-app/templates/validation-webhook-configuration.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingressController.validationController.enabled }}
+{{- $cn := printf "%s.%s.svc" (print (include "kong.fullname" .) "-validation") .Release.Namespace }}
+{{- $altNames := list ( print (include "kong.fullname" .) "-validation" ) ( printf "%s.%s" (print (include "kong.fullname" .) "-validation") .Release.Namespace ) ( printf "%s.%s.svc" (print (include "kong.fullname" .) "-validation") .Release.Namespace ) -}}
+{{- $ca := genCA (printf "%s.%s.svc" (print (include "kong.fullname" .) "-validation") .Release.Namespace) 365 -}}
+{{- $cert := genSignedCert $cn nil $altNames 365 $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kong.fullname" . }}-validation
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ template "kong.fullname" . }}-validation
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+webhooks:
+- name: validations.kong.konghq.com
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - "*"
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongplugins
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ template "kong.fullname" . }}-validation
+    caBundle: {{ $ca.Cert | b64enc }}
+{{- end }}

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -426,6 +426,9 @@ ingressController:
 
   installCRDs: true
 
+  validationController:
+    enabled: true
+
   rbac:
     # Specifies whether RBAC resources should be created
     create: true


### PR DESCRIPTION
The latest version of Kong Ingress Controller comes with the validation controller integrated. Add the option to deploy it (by default true)