### PR TITLE
Add postgres user and database env vars to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.4.3]
+
+## Added
+
+- Add Postgres user and database name as environment variables in the proper templates.
+
 ## [v0.4.2]
 
 ## Changed

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -211,6 +211,10 @@ Create the ingress servicePort value string
     value: {{ template "kong.postgresql.fullname" . }}
   - name: KONG_PG_PORT
     value: "{{ .Values.postgresql.service.port }}"
+  - name: KONG_PG_USER
+    value: "{{ .Values.postgresql.postgresqlUsername }}"
+  - name: KONG_PG_DATABASE
+    value: "{{ .Values.postgresql.postgresqlDatabase }}"
   - name: KONG_PG_PASSWORD
     valueFrom:
       secretKeyRef:
@@ -221,6 +225,10 @@ Create the ingress servicePort value string
   {{- else if .Values.postgresql.external.enabled }}
   - name: KONG_PG_HOST
     value: {{ .Values.postgresql.external.host }}
+  - name: KONG_PG_USER
+    value: "{{ .Values.postgresql.postgresqlUsername }}"
+  - name: KONG_PG_DATABASE
+    value: "{{ .Values.postgresql.postgresqlDatabase }}"
   - name: KONG_PG_PORT
     value: "{{ .Values.postgresql.external.port }}"
   - name: KONG_LUA_PACKAGE_PATH

--- a/helm/kong-app/templates/deployment.yaml
+++ b/helm/kong-app/templates/deployment.yaml
@@ -152,6 +152,10 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD
@@ -162,6 +166,10 @@ spec:
         {{- else if .Values.postgresql.external.enabled }}
         - name: KONG_PG_HOST
           value: {{ .Values.postgresql.external.host }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD

--- a/helm/kong-app/templates/migrations-post-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-post-upgrade.yaml
@@ -37,6 +37,10 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD
@@ -47,6 +51,10 @@ spec:
         {{- else if .Values.postgresql.external.enabled }}
         - name: KONG_PG_HOST
           value: {{ .Values.postgresql.external.host }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.external.port }}"
         - name: KONG_PG_PASSWORD
@@ -74,6 +82,10 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD
@@ -84,6 +96,10 @@ spec:
         {{- else if .Values.postgresql.external.enabled }}
         - name: KONG_PG_HOST
           value: {{ .Values.postgresql.external.host }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.external.port }}"
         - name: KONG_PG_PASSWORD

--- a/helm/kong-app/templates/migrations-pre-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-pre-upgrade.yaml
@@ -37,6 +37,10 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD
@@ -47,6 +51,10 @@ spec:
         {{- else if .Values.postgresql.external.enabled }}
         - name: KONG_PG_HOST
           value: {{ .Values.postgresql.external.host }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.external.port }}"
         - name: KONG_PG_PASSWORD
@@ -74,6 +82,10 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD
@@ -84,6 +96,10 @@ spec:
         {{- else if .Values.postgresql.external.enabled }}
         - name: KONG_PG_HOST
           value: {{ .Values.postgresql.external.host }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.external.port }}"
         - name: KONG_PG_PASSWORD

--- a/helm/kong-app/templates/migrations.yaml
+++ b/helm/kong-app/templates/migrations.yaml
@@ -32,6 +32,10 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD
@@ -42,6 +46,10 @@ spec:
         {{- else if .Values.postgresql.external.enabled }}
         - name: KONG_PG_HOST
           value: {{ .Values.postgresql.external.host }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.external.port }}"
         - name: KONG_PG_PASSWORD
@@ -70,6 +78,10 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.service.port }}"
         - name: KONG_PG_PASSWORD
@@ -80,6 +92,10 @@ spec:
         {{- else if .Values.postgresql.external.enabled }}
         - name: KONG_PG_HOST
           value: {{ .Values.postgresql.external.host }}
+        - name: KONG_PG_USER
+          value: "{{ .Values.postgresql.postgresqlUsername }}"
+        - name: KONG_PG_DATABASE
+          value: "{{ .Values.postgresql.postgresqlDatabase }}"
         - name: KONG_PG_PORT
           value: "{{ .Values.postgresql.external.port }}"
         - name: KONG_PG_PASSWORD


### PR DESCRIPTION
When external DB is used then user and database name has to be added explicitly. 