### PR TITLE
Support for plugin with multiple configmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.4.5]
+
+## Added
+
+- Add support for plugins which require multiple configmaps.
+
 ## [v0.4.4]
 
 ## Removed

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -138,7 +138,7 @@ Create the ingress servicePort value string
 
 {{- define "kong.volumes" -}}
 {{- range .Values.plugins.configMaps }}
-- name: kong-plugin-{{ .pluginName }}
+- name: kong-plugin-{{ empty .path | ternary .pluginName .name }}
   configMap:
     name: {{ .name }}
 {{- end }}
@@ -178,12 +178,12 @@ Create the ingress servicePort value string
   mountPath: /etc/secrets/{{ . }}
 {{- end }}
 {{- range .Values.plugins.configMaps }}
-- name:  kong-plugin-{{ .pluginName }}
-  mountPath: /opt/kong/plugins/{{ .pluginName }}
+- name:  kong-plugin-{{ empty .path | ternary .pluginName .name }}
+  mountPath: /opt/kong/plugins/{{ coalesce .path .pluginName }}
 {{- end }}
 {{- range .Values.plugins.secrets }}
-- name:  kong-plugin-{{ .pluginName }}
-  mountPath: /opt/kong/plugins/{{ .pluginName }}
+- name:  kong-plugin-{{ empty .path | ternary .pluginName .name }}
+  mountPath: /opt/kong/plugins/{{ coalesce .path .pluginName }}
 {{- end }}
 {{- end -}}
 
@@ -195,7 +195,7 @@ Create the ingress servicePort value string
 {{- range .Values.plugins.secrets -}}
   {{ $myList = append $myList .pluginName -}}
 {{- end }}
-{{- $myList | join "," -}}
+{{- $myList | uniq | join "," -}}
 {{- end -}}
 
 {{- define "kong.wait-for-db" -}}


### PR DESCRIPTION
This commit addresses #491 concerning supporting plugins which require
multiple configmaps, which is the case if they require a migrations
folder for any relational datastore support they have implemented.

An example input for values.yaml I used to test this was:

```
plugins:
  configMaps:
  - pluginName: key-auth-secret
    name: key-auth-secret-root
  - pluginName: key-auth-secret
    name: key-auth-secret-migrations
    path: key-auth-secret/migrations
```

cc/ @pipo02mix @narsipra