### PR TITLE
FIX: Kill wait-for-postgres if host or port not set

### DIFF
--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -439,6 +439,8 @@ the template that it itself is using form the above sections.
   {{- $_ := set $autoEnv "KONG_PG_PORT" .Values.postgresql.service.port -}}
   {{- $pgPassword := include "secretkeyref" (dict "name" (include "kong.postgresql.fullname" .) "key" "postgresql-password") -}}
   {{- $_ := set $autoEnv "KONG_PG_PASSWORD" $pgPassword -}}
+{{- else if eq .Values.env.database "postgres" }}
+  {{- $_ := set $autoEnv "KONG_PG_PORT" "5432" }}
 {{- end }}
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
@@ -492,5 +494,5 @@ the template that it itself is using form the above sections.
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
   {{- include "kong.no_daemon_env" . | nindent 2 }}
-  command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+  command: [ "/bin/sh", "-c", "set -u; until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo \"waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}\"; sleep 1; done" ]
 {{- end -}}


### PR DESCRIPTION
Fixes #38

The script runs forever and simply prints 'waiting for db' if KONG_PG_HOST or
KONG_PG_PORT are not set. Which isn't very helpful.

This commit hard fails if either of those environment variables are not set,
making it easier and quicker to diagnose problems.

As a note, the reason why they may not be set is when a user provides there own
database but doesn't set pg_port or pg_host.

Additional changes:
 - Message is slightly more informative, so if connecting takes awhile,
the use can see host and port being attempted.
 - Set the default postgres port