### PR TITLE
[PATCH] Ensure environment variables map is ordered

### DIFF
--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -464,7 +464,7 @@ the template that it itself is using form the above sections.
 
 {{- $completeEnv := mergeOverwrite $autoEnv $userEnv -}}
 
-{{- range keys $completeEnv }}
+{{- range keys $completeEnv | sortAlpha }}
 {{- $val := pluck . $completeEnv | first -}}
 {{- $valueType := printf "%T" $val -}}
 {{ if eq $valueType "map[string]interface {}" }}


### PR DESCRIPTION
Since we are dealing with maps, there is zero guarantee that the output yaml will
be the same between runs. In most cases this is not an issue, but the env map is
used by jobs. In this case `spec.template` is immutable and if the env list
order changes, it results in a failed upgrade.

So in the construction of the map, we ensure (by ordering the list of keys) that
it is idempotent.