### PR TITLE
Don't recreate service account

### DIFF
--- a/helm/kong-app/README.md
+++ b/helm/kong-app/README.md
@@ -257,6 +257,8 @@ section of `values.yaml` file:
 | image.tag                          | Version of the ingress controller                                                     | 0.7.0                                                                        |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
+| serviceAccount.create              | Create Service Account for IngresController                                           | true
+| serviceAccount.name                | Use existing Service Account, specifiy it's name                                      | ""
 | installCRDs                        | Create CRDs. Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation. | true |
 | env                                | Specify Kong Ingress Controller configuration via environment variables               |                                                                              |
 | ingressClass                       | The ingress-class value for controller                                                | kong                                                                         |
@@ -267,6 +269,20 @@ section of `values.yaml` file:
 For a complete list of all configuration values you can set in the
 `env` section, please read the Kong Ingress Controller's
 [configuration document](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/references/cli-arguments.md).
+
+#### Service Accounts
+By default, a service account is created, however older versions of the chart
+did not create the service account. So if you are upgrading from a chart that
+didn't create the service account, then you will need to create a service
+account and specifiy the name.
+
+You can use `helm template` to generate the YAML needed to create the service
+account. The following is an example:
+
+```shell
+helm template --namespace <existing-app-namespace> --name <existing-app-name> kong -x templates/controller-service-account.yaml | kubectl apply -f -
+helm upgrade --set ingressController.serviceAccount.create=false --set ingressController.serviceAccount.name=<name-of-service-account> <existing-app-name> kong
+```
 
 ### General Parameters
 
@@ -501,7 +517,7 @@ value is your SMTP password.
 
 ### 1.0.2
 
-- Helm 3 support: CRDs are declared in crds directory. Backward compatible support for helm 2. 
+- Helm 3 support: CRDs are declared in crds directory. Backward compatible support for helm 2.
 
 ### 1.0.1
 

--- a/helm/kong-app/templates/migrations-pre-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-pre-upgrade.yaml
@@ -47,17 +47,3 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
 {{- end }}
-
-{{ if or .Values.podSecurityPolicy.enabled (and .Values.ingressController.enabled .Values.ingressController.serviceAccount.create) -}}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "kong.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-{{- end -}}


### PR DESCRIPTION
Helm upgrade recreates service account, which in turn recreates the secret token
for the service account. This breaks current deployments. Below are symptoms:

Before Upgrade:
--------------

```
kubectl -n kong get serviceaccount -l app.kubernetes.io/name=kong-app -o jsonpath='{.items[].secrets}'
[map[name:kong-tst-kong-app-token-k7qv2]]
```

```
kubectl -n kong get pod kong-tst-kong-app-cc9787b65-fwzrd -o json | jq '.spec.containers[] | select(.name == "ingress-controller").volumeMounts'
[
  {
    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
    "name": "kong-tst-kong-app-token-k7qv2",
    "readOnly": true
  }
]
```

(Note: Token is the same)

After Upgrade:
-------------

```
kubectl -n kong get serviceaccount -l app.kubernetes.io/name=kong-app -o jsonpath='{.items[].secrets}'
[map[name:kong-tst-kong-app-token-rrzfh]]
```

```
kubectl -n kong get pod kong-tst-kong-app-cc9787b65-fwzrd -o json | jq '.spec.containers[] | select(.name == "ingress-controller").volumeMounts'
[
  {
    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
    "name": "kong-tst-kong-app-token-k7qv2",
    "readOnly": true
  }
]
```

(Note: Tokens are different)

From the logs (after upgrade):

Tiller:
------
```
[tiller] 2020/01/31 17:01:46 deleting pre-upgrade hook kong-tst-kong-app for release kong-tst due to "before-hook-creation" policy
[kube] 2020/01/31 17:01:46 Starting delete for "kong-tst-kong-app" ServiceAccount
[kube] 2020/01/31 17:01:46 Waiting for 60 seconds for delete to be completed
[kube] 2020/01/31 17:01:48 building resources from manifest
[kube] 2020/01/31 17:01:48 creating 1 resource(s)
[kube] 2020/01/31 17:01:48 Watching for changes to ServiceAccount kong-tst-kong-app with timeout of 5m0s
[kube] 2020/01/31 17:01:48 Add/Modify event for kong-tst-kong-app: ADDED
```

From IngresController:
----------------------
```
E0131 18:09:30.368424       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to list *v1beta1.Ingress: Unauthorized
E0131 18:09:31.206518       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to list *v1.KongCredential: Unauthorized
E0131 18:09:31.371432       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to list *v1beta1.Ingress: Unauthorized
E0131 18:09:32.214002       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to list *v1.KongCredential: Unauthorized
E0131 18:09:32.379662       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to list *v1beta1.Ingress: Unauthorized
```

This is due to a pre hook that creates the service account and then deletes
(then is created again).

Stop this behaviour and document manual upgrades.