### PR TITLE
add metrics service template

### DIFF
--- a/helm/kong-app/templates/service-kong-metrics.yaml
+++ b/helm/kong-app/templates/service-kong-metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-metrics
+  annotations:
+    prometheus.io/scheme: http
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9542'
+spec:
+  ports:
+  - name: {{ template "kong.fullname" . }}-metrics
+    port: 9542
+    protocol: TCP
+    targetPort: 9542
+  selector:
+{{- include "kong.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/8415

The metrics endpoint is already exposed by an nginx server block included in the chart, and the relevant port is already exposed on the container by default. Exposing the metrics this way instead of via the admin API follows the security recommendations from Kong, and it means customers can enable/disable the admin API as they see fit without affecting our monitoring.