### PR TITLE
Change ingressClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Ingress Controller
 [documentation](https://github.com/Kong/kubernetes-ingress-controller/tree/master/docs)
 for more detailed explanation and usage.
 
+#### Ingress Controller Class
+The default ingress controller class used by this app is `kong-app`. This
+differs from the upstream default `kong`. We have changed the defualt, as this
+conflicts with other ingress controllers and the default ingress controller in
+Giant Searm clusters is `nginx`.
+
+For more details about this please have a look [upstream deployment
+documentation](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md#multiple-ingress-controllers)
+
 ### DBLess Kong
 The [official documentation](https://docs.konghq.com/1.4.x/db-less-and-declarative-config/)
 explains how DBLess Kong works and the possible limitations. To use this method

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ for more detailed explanation and usage.
 
 #### Ingress Controller Class
 The default ingress controller class used by this app is `kong-app`. This
-differs from the upstream default `kong`. We have changed the defualt, as this
+differs from the upstream default `kong`. We have changed the default, as this
 conflicts with other ingress controllers and the default ingress controller in
-Giant Searm clusters is `nginx`.
+Giant Swarm clusters is `nginx`.
 
 For more details about this please have a look [upstream deployment
 documentation](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md#multiple-ingress-controllers)

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -204,7 +204,11 @@ ingressController:
     failurePolicy: Fail
     port: 8080
 
-  ingressClass: kong
+  # This has been changed from the default `kong`
+  # as it allows this app to exist alongside other
+  # ingress controllers, such as nginx which is the
+  # default in the cluster.
+  ingressClass: kong-app
 
   rbac:
     # Specifies whether RBAC resources should be created


### PR DESCRIPTION
The default ingress controller class used by this app is `kong-app`. This
differs from the upstream default `kong`. We have changed the defualt, as this
conflicts with other ingress controllers and the default ingress controller in
Giant Searm clusters is `nginx`.

For more details about this please have a look [upstream deployment
documentation](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md#multiple-ingress-controllers)