### PR TITLE
Fix default webhook value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Force cast to string for Admission Webhook port [#59](https://github.com/giantswarm/kong-app/pull/59)
+
 ## [v0.8.3] - 2020-06-17
 
 ### Fixed

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -190,7 +190,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
 {{- $_ := set $autoEnv "CONTROLLER_KONG_URL" (include "kong.adminLocalURL" .) -}}
 {{- if .Values.ingressController.admissionWebhook.enabled }}
-  {{- $_ := set $autoEnv "CONTROLLER_ADMISSION_WEBHOOK_LISTEN" (printf "0.0.0.0:%s" .Values.ingressController.admissionWebhook.port) -}}
+  {{- $_ := set $autoEnv "CONTROLLER_ADMISSION_WEBHOOK_LISTEN" (printf "0.0.0.0:%s" (.Values.ingressController.admissionWebhook.port | toString)) -}}
 {{- end }}
 
 {{/*

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -282,7 +282,7 @@ ingressController:
   admissionWebhook:
     enabled: false
     failurePolicy: Fail
-    port: 8080
+    port: "8080"
 
   # This has been changed from the default `kong`
   # as it allows this app to exist alongside other


### PR DESCRIPTION
Doesn't matter what type is set in the value file, we always want a string, so
we should cast it to be sure.

This fixes giantswarm/adidas#560