### PR TITLE
Cover 0.9.1 changes in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [0.9.1] - 2020-08-25
 
+### Changed
+
+- Split registry value to allow switching registry
+
 ## [0.9.0] - 2020-08-25
 
 ### Updated


### PR DESCRIPTION
This PR covers https://github.com/giantswarm/kong-app/pull/64 in the changelog.