### PR TITLE
Prepare 0.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## [0.9.1] - 2020-08-25
+### Changed
+
+- Split registry value to allow switching registry.
 
 ## [0.9.0] - 2020-08-25
 
@@ -211,8 +213,7 @@ From upstream CHANGELOG:
 - Use service of type Load Balancer for the Kong proxy service.
 - Disable using Postgres and use Kubernetes resources for storing state.
 
-[Unreleased]: https://github.com/giantswarm/kong-app/compare/v0.9.1...HEAD
-[0.9.1]: https://github.com/giantswarm/kong-app/compare/v0.9.0...v0.9.1
+[Unreleased]: https://github.com/giantswarm/kong-app/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/giantswarm/kong-app/compare/v0.8.3...v0.9.0
 [v0.8.3]: https://github.com/giantswarm/kong-app/compare/v0.8.2..v0.8.3
 [v0.8.2]: https://github.com/giantswarm/kong-app/compare/v0.8.1..v0.8.2


### PR DESCRIPTION
0.9.1 although already shared with customer, hasn't actually been released
- there are no 0.9.1 Release/Tags https://github.com/giantswarm/kong-app/releases
- there is no 0.9.1 kong-app Helm package in giantswarm catalog https://github.com/giantswarm/giantswarm-catalog

This PR prepares another release attempt.

I believe previous 2 release attempts via GitHub workflows failed due to use of merge commit. I've updated the repo merge button settings to squash commits https://github.com/giantswarm/kong-app/settings