### PR TITLE
use architect-orb 0.15.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.11.0
+  architect: giantswarm/architect@0.15.1
 
 workflows:
   package-and-push-chart-on-tag:


### PR DESCRIPTION
This PR bumps the used architect-orb version to use a pinned `kube-app-testing.sh` version.