### PR TITLE
Add values schema to Kong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [0.9.0] - 2020-08-25
 
 ### Updated
+
 - Upgraded architect-orb to 0.10.0
 - Add github workflows for release automation
 - Sync with upstream chart [v1.8.0](https://github.com/Kong/charts/tree/kong-1.8.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [0.9.0] - 2020-08-25
 
 ### Updated
- 
 - Upgraded architect-orb to 0.10.0
 - Add github workflows for release automation
 - Sync with upstream chart [v1.8.0](https://github.com/Kong/charts/tree/kong-1.8.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+- Added values.schema.json for validation of default values
+
 ## [1.1.0] - 2020-12-02
 
 ### Updated
@@ -35,7 +38,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Updated
 
 - Update architect-orb to 0.11.0
-- Sync with upstream chart [1.11.0](https://github.com/Kong/charts/tree/kong-1.11.0). Please check the upstream [changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#1110).
+- Sync with upstream chart [1.11.0](https://github.com/Kong/charts/tree/kong-1.11.0)
+- Please check the upstream [CHANGELOG.md](/helm/kong-app/CHANGELOG.md)
 
 ### Changed
 
@@ -50,7 +54,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [0.9.0] - 2020-08-25
 
 ### Updated
-
+ 
 - Upgraded architect-orb to 0.10.0
 - Add github workflows for release automation
 - Sync with upstream chart [v1.8.0](https://github.com/Kong/charts/tree/kong-1.8.0)
@@ -249,8 +253,7 @@ From upstream CHANGELOG:
 - Use service of type Load Balancer for the Kong proxy service.
 - Disable using Postgres and use Kubernetes resources for storing state.
 
-[Unreleased]: https://github.com/giantswarm/kong-app/compare/v1.1.0...HEAD
-[1.1.0]: https://github.com/giantswarm/kong-app/compare/v1.0.0...v1.1.0
+[Unreleased]: https://github.com/giantswarm/kong-app/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/giantswarm/kong-app/compare/v0.9.1...v1.0.0
 [0.9.1]: https://github.com/giantswarm/kong-app/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/giantswarm/kong-app/compare/v0.8.3...v0.9.0

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -11,5 +11,7 @@ maintainers:
 name: kong-app
 sources:
 - https://raw.githubusercontent.com/giantswarm/kong-app/v[[ .Version ]]/README.md
+annotations:
+  application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/kong-app/v[[ .Version ]]/helm/kong-app/values.schema.json
 version: [[ .Version ]]
 appVersion: 2.2

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -1,0 +1,1164 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "admin": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hostname": {
+                            "type": "null"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxReplicas": {
+                    "type": "integer"
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "resource": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "target": {
+                                        "type": "object",
+                                        "properties": {
+                                            "averageUtilization": {
+                                                "type": "integer"
+                                            },
+                                            "type": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "minReplicas": {
+                    "type": "integer"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "null"
+                }
+            }
+        },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalIPs": {
+                    "type": "array"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "clustertelemetry": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalIPs": {
+                    "type": "array"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dblessConfig": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "_format_version": {
+                            "type": "string"
+                        },
+                        "services": {
+                            "type": "null"
+                        }
+                    }
+                },
+                "configMap": {
+                    "type": "string"
+                }
+            }
+        },
+        "deployment": {
+            "type": "object",
+            "properties": {
+                "kong": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "deploymentAnnotations": {
+            "type": "object",
+            "properties": {
+                "kuma.io/gateway": {
+                    "type": "string"
+                },
+                "traffic.sidecar.istio.io/includeInboundPorts": {
+                    "type": "string"
+                }
+            }
+        },
+        "enterprise": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "license_secret": {
+                    "type": "string"
+                },
+                "portal": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "admin_gui_auth": {
+                            "type": "string"
+                        },
+                        "admin_gui_auth_conf_secret": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "session_conf_secret": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "smtp": {
+                    "type": "object",
+                    "properties": {
+                        "admin_emails_from": {
+                            "type": "string"
+                        },
+                        "admin_emails_reply_to": {
+                            "type": "string"
+                        },
+                        "auth": {
+                            "type": "object",
+                            "properties": {
+                                "smtp_password_secret": {
+                                    "type": "string"
+                                },
+                                "smtp_username": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "portal_emails_from": {
+                            "type": "string"
+                        },
+                        "portal_emails_reply_to": {
+                            "type": "string"
+                        },
+                        "smtp_admin_emails": {
+                            "type": "string"
+                        },
+                        "smtp_auth_type": {
+                            "type": "string"
+                        },
+                        "smtp_host": {
+                            "type": "string"
+                        },
+                        "smtp_port": {
+                            "type": "integer"
+                        },
+                        "smtp_ssl": {
+                            "type": "string"
+                        },
+                        "smtp_starttls": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "vitals": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "env": {
+            "type": "object",
+            "properties": {
+                "admin_access_log": {
+                    "type": "string"
+                },
+                "admin_error_log": {
+                    "type": "string"
+                },
+                "admin_gui_access_log": {
+                    "type": "string"
+                },
+                "admin_gui_error_log": {
+                    "type": "string"
+                },
+                "database": {
+                    "type": "string"
+                },
+                "nginx_worker_processes": {
+                    "type": "string"
+                },
+                "portal_api_access_log": {
+                    "type": "string"
+                },
+                "portal_api_error_log": {
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "proxy_access_log": {
+                    "type": "string"
+                },
+                "proxy_error_log": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "ingressController": {
+            "type": "object",
+            "properties": {
+                "admissionWebhook": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "failurePolicy": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "args": {
+                    "type": "array"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "env": {
+                    "type": "object",
+                    "properties": {
+                        "kong_admin_tls_skip_verify": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ingressClass": {
+                    "type": "string"
+                },
+                "installCRDs": {
+                    "type": "boolean"
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "scheme": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "rbac": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "scheme": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "null"
+                        }
+                    }
+                }
+            }
+        },
+        "lifecycle": {
+            "type": "object",
+            "properties": {
+                "preStop": {
+                    "type": "object",
+                    "properties": {
+                        "exec": {
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "manager": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalIPs": {
+                    "type": "array"
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hostname": {
+                            "type": "null"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "migrations": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "kuma.io/sidecar-injection": {
+                            "type": "string"
+                        },
+                        "sidecar.istio.io/inject": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "postUpgrade": {
+                    "type": "boolean"
+                },
+                "preUpgrade": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "plugins": {
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "object",
+            "properties": {
+                "giantswarm.io/monitoring": {
+                    "type": "string"
+                },
+                "giantswarm.io/monitoring-path": {
+                    "type": "string"
+                },
+                "giantswarm.io/monitoring-port": {
+                    "type": "string"
+                },
+                "prometheus.io/port": {
+                    "type": "string"
+                },
+                "prometheus.io/scrape": {
+                    "type": "string"
+                }
+            }
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxUnavailable": {
+                    "type": "string"
+                }
+            }
+        },
+        "podLabels": {
+            "type": "object"
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "spec": {
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                        },
+                        "fsGroup": {
+                            "type": "object",
+                            "properties": {
+                                "rule": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "hostIPC": {
+                            "type": "boolean"
+                        },
+                        "hostNetwork": {
+                            "type": "boolean"
+                        },
+                        "hostPID": {
+                            "type": "boolean"
+                        },
+                        "privileged": {
+                            "type": "boolean"
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                        },
+                        "runAsGroup": {
+                            "type": "object",
+                            "properties": {
+                                "rule": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "runAsUser": {
+                            "type": "object",
+                            "properties": {
+                                "rule": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "seLinux": {
+                            "type": "object",
+                            "properties": {
+                                "rule": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "supplementalGroups": {
+                            "type": "object",
+                            "properties": {
+                                "rule": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "portal": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalIPs": {
+                    "type": "array"
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hostname": {
+                            "type": "null"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "portalapi": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalIPs": {
+                    "type": "array"
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hostname": {
+                            "type": "null"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "proxy": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalIPs": {
+                    "type": "array"
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array"
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hosts": {
+                            "type": "array"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "stream": {
+                    "type": "object"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "servicePort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "secretVolumes": {
+            "type": "array"
+        },
+        "securityContext": {
+            "type": "object"
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "status": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "updateStrategy": {
+            "type": "object"
+        },
+        "waitImage": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -1008,7 +1008,7 @@
                     }
                 },
                 "stream": {
-                    "type": "object"
+                    "type": "array"
                 },
                 "tls": {
                     "type": "object",

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -389,7 +389,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     }
                 },

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -198,7 +198,7 @@ proxy:
   # To enable, remove "{}", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their servicePort,
   # e.g. "stream-9000" for the below.
-  stream: {}
+  stream: []
     #   # Set the container (internal) and service (external) ports for this listen.
     #   # These values should normally be the same. If your environment requires they
     #   # differ, note that Kong will match routes based on the containerPort only.

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -195,7 +195,7 @@ proxy:
     - http2
 
   # Define stream (TCP) listen
-  # To enable, remove "{}", uncomment the section below, and select your desired
+  # To enable, remove "[]", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their servicePort,
   # e.g. "stream-9000" for the below.
   stream: []

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -329,7 +329,7 @@ ingressController:
   admissionWebhook:
     enabled: false
     failurePolicy: Fail
-    port: "8080"
+    port: 8080
 
   # This has been changed from the default `kong`
   # as it allows this app to exist alongside other


### PR DESCRIPTION
<!--
@app-squad-kongwill be automatically requested for review once
this PR has been submitted.
-->

Towards https://github.com/giantswarm/roadmap/issues/136 with @oponder 

This PR adds `values.schema.json` generated from the current values.yaml using https://github.com/karuppiah7890/helm-schema-gen

It is a good starting point and can be further refined by those that know more about the specifics of the values. (For example if we know that `provider` must be aws|azure|kvm, we can actually enforce that as well using the 'enum' property: https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values)

Here's also some more general info: https://www.arthurkoziel.com/validate-helm-chart-values-with-json-schemas/

I tested in qmyk0 in asgard and got the following error:

```
(⎈ |giantswarm-asgard:default)➜  kubectl-gs git:(app-validate) ./kubectl-gs validate apps -n qmyk0 kong-app -f=/Users/chiaracokieng/Documents/GitHub/kong-app/helm/kong-app/values.schema.json -o report

Validated 1 app across 1 namespace

qmyk0 [1 app, 1 error]
  kong-app:
    ingressController.admissionWebhook.port - Invalid type. Expected: string, given: integer - 8080
```

@giantswarm/app-squad-kong In line 328 here https://github.com/giantswarm/kong-app/blob/master/helm/kong-app/values.yaml, it says. Should 8080 be inside " "?

```
admissionWebhook:
    enabled: false
    failurePolicy: Fail
    port: "8080"
```

---

I used the currently in progress `kubectl-gs validate apps` command to help with the verifying current values : https://github.com/giantswarm/kubectl-gs/pull/196

Here's also a slack thread with a video about how that command works: https://gigantic.slack.com/archives/CRZN9GLJW/p1603092812002400