### PR TITLE
Don't set waitImage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
           name: "test with kat"
           chart: "kong-app"
           ct_config: ".circleci/ct-config.yaml"
+          kube-app-testing-version: "fix-helm-url"
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,18 +5,8 @@ orbs:
 workflows:
   package-and-push-chart-on-tag:
     jobs:
-      - architect/run-kat-tests:
-          name: "test with kat"
-          chart: "kong-app"
-          ct_config: ".circleci/ct-config.yaml"
-          kube-app-testing-version: "fix-helm-url"
-          filters:
-            tags:
-              only: /^v.*/
       - architect/push-to-app-catalog:
           name: "package and push kong-app chart"
-          requires:
-            - "test with kat"
           app_catalog: "giantswarm-catalog"
           app_catalog_test: "giantswarm-test-catalog"
           chart: "kong-app"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Do not set `waitImage.repository` in alignment with upstream.
+
 ## [1.1.1] - 2021-03-02
 
 ### Added

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -14,4 +14,4 @@ sources:
 annotations:
   application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/kong-app/v[[ .Version ]]/helm/kong-app/values.schema.json
 version: [[ .Version ]]
-appVersion: 2.2
+appVersion: "2.2"

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -650,8 +650,10 @@ Environment variables are sorted alphabetically
 - name: wait-for-postgres
 {{- if .Values.waitImage.unifiedRepoTag }}
   image: "{{ .Values.waitImage.unifiedRepoTag }}"
-{{- else }}
+{{- else if .Values.waitImage.repository }}
   image: "{{ .Values.image.registry }}/{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+{{- else }} {{/* default to the Kong image */}}
+  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 {{- end }}
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -38,7 +38,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         },
                         "path": {
                             "type": "string"
@@ -113,7 +113,7 @@
                     "type": "integer"
                 },
                 "targetCPUUtilizationPercentage": {
-                    "type": "integer"
+                    "type": ["null", "integer"]
                 }
             }
         },
@@ -195,7 +195,7 @@
                             "type": "string"
                         },
                         "services": {
-                            "type": "array"
+                            "type": ["null", "array"]
                         }
                     }
                 },
@@ -537,7 +537,7 @@
                             "type": "boolean"
                         },
                         "name": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         }
                     }
                 }
@@ -637,7 +637,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         },
                         "path": {
                             "type": "string"
@@ -847,7 +847,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         },
                         "path": {
                             "type": "string"
@@ -918,7 +918,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         },
                         "path": {
                             "type": "string"

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -38,7 +38,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "path": {
                             "type": "string"
@@ -113,7 +113,7 @@
                     "type": "integer"
                 },
                 "targetCPUUtilizationPercentage": {
-                    "type": "null"
+                    "type": "integer"
                 }
             }
         },
@@ -195,7 +195,7 @@
                             "type": "string"
                         },
                         "services": {
-                            "type": "null"
+                            "type": "array"
                         }
                     }
                 },
@@ -537,7 +537,7 @@
                             "type": "boolean"
                         },
                         "name": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 }
@@ -637,7 +637,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "path": {
                             "type": "string"
@@ -847,7 +847,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "path": {
                             "type": "string"
@@ -918,7 +918,7 @@
                             "type": "boolean"
                         },
                         "hostname": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "path": {
                             "type": "string"

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -410,8 +410,17 @@ postgresql:
 # -----------------------------------------------------------------------------
 
 waitImage:
-  repository: giantswarm/bash
-  tag: 5.0
+  # Wait for the database to come online before starting Kong or running migrations
+  # If Kong is to access the database through a service mesh that injects a sidecar to
+  # Kong's container, this must be disabled. Otherwise there'll be a deadlock:
+  # InitContainer waiting for DB access that requires the sidecar, and the sidecar
+  # waiting for InitContainers to finish.
+  enabled: true
+  # Optionally specify an image that provides bash for pre-migration database
+  # checks. If none is specified, the chart uses the Kong image. The official
+  # Kong images provide bash
+  # repository: giantswarm/bash
+  # tag: 5
   pullPolicy: IfNotPresent
 
 # update strategy


### PR DESCRIPTION
Align `waitImage` values with upstream. When set, its used for initContainers. Upstream changed to not setting it and using the default kong image.
