### PR TITLE
Upgrade from upstream kong-2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@2.11.0
+  architect: giantswarm/architect@3.2.0
 
 workflows:
   package-and-push-chart-on-tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Updates
+
+- Update to align with upstream chart [2.1.0](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#210) which includes updates for kong to [2.4.1](https://github.com/Kong/kong/blob/master/CHANGELOG.md#241) and kong ingress controller [1.2.0](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#120---20210324). For more information check the linked changelogs.
+
 ## [2.0.0] - 2021-05-07
 
 2.0.0 marks the stable release of synchronization with upstream [2.0.0](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#200).

--- a/helm/kong-app/CHANGELOG.md
+++ b/helm/kong-app/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.1.0
+
+### Improvements
+
+* Added support for user-defined volumes, volume mounts, and init containers.
+  ([#317](https://github.com/Kong/charts/pull/317))
+* Tolerations are now applied to migration Job Pods also.
+  ([#341](https://github.com/Kong/charts/pull/341))
+* Added support for using a DaemonSet instead of Deployment.
+  ([#347](https://github.com/Kong/charts/pull/347))
+* Updated default image versions and completed migration off Bintray
+  repositories.
+  ([#349](https://github.com/Kong/charts/pull/349))
+* PDB ignores migration Job Pods.
+  ([#352](https://github.com/Kong/charts/pull/352))
+
+### Documentation
+
+* Clarified service monitor usage information.
+  ([#345](https://github.com/Kong/charts/pull/345))
+
 ## 2.0.0
 
 ### Breaking changes

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -14,4 +14,4 @@ sources:
 annotations:
   application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/kong-app/v[[ .Version ]]/helm/kong-app/values.schema.json
 version: [[ .Version ]]
-appVersion: "2.3.3"
+appVersion: "2.4.1"

--- a/helm/kong-app/README.md
+++ b/helm/kong-app/README.md
@@ -32,7 +32,11 @@ $ helm install kong/kong --generate-name
   - [Standalone controller nodes](#standalone-controller-nodes)
   - [Hybrid mode](#hybrid-mode)
   - [CRD management](#crd-management)
+  - [InitContainers](#initContainers)
   - [Sidecar containers](#sidecar-containers)
+  - [User Defined Volumes](#user-defined-volumes)
+  - [User Defined Volume Mounts](#user-defined-volume-mounts)
+  - [Using a DaemonSet](#using-a-daemonset)
   - [Example configurations](#example-configurations)
 - [Configuration](#configuration)
   - [Kong Parameters](#kong-parameters)
@@ -426,6 +430,10 @@ you do (your resources will have a `meta.helm.sh/release-name` annotation), we
 _strongly_ recommend that you back up all associated custom resources in the
 event you need to recover from unintended CRD deletion.
 
+### InitContainers
+
+The chart able to deploy initcontainers along with Kong. This can be very useful when require to setup additional custom initialization. The `deployment.initcontainers` field in values.yaml takes an array of objects that get appended as-is to the existing `spec.template.initContainers` array in the kong deployment resource. 
+
 ### Sidecar Containers
 
 The chart can deploy additional containers along with the Kong and Ingress
@@ -434,6 +442,21 @@ be useful to include network proxies or logging services along with Kong.  The
 `deployment.sidecarContainers` field in values.yaml takes an array of objects
 that get appended as-is to the existing `spec.template.spec.containers` array
 in the Kong deployment resource.
+
+### User Defined Volumes
+
+The chart can deploy additional volumes along with Kong. This can be useful to include additional volumes which required during iniatilization phase (InitContainer). The  `deployment.userDefinedVolumes` field in values.yaml takes an array of objects that get appended as-is to the existing `spec.template.spec.volumes` array in the kong deployment resource.
+
+### User Defined Volume Mounts
+
+The chart can mount the volumes which defined in the `user defined volume` or others. The `deployment.userDefinedVolumeMounts` field in values.yaml takes an array of object that get appended as-is to the existing `spec.template.spec.containers[].volumeMounts` and `spec.template.spec.initContainers[].volumeMounts` array in the kong deployment resource.
+
+### Using a DaemonSet
+
+Setting `deployment.daemonset: true` deploys Kong using a [DaemonSet
+controller](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+instead of a Deployment controller. This runs a Kong Pod on every kubelet in
+the Kubernetes cluster.
 
 ### Example configurations
 
@@ -448,7 +471,7 @@ directory.
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
-| image.tag                          | Kong image version                                                                    | `2.0`               |
+| image.tag                          | Kong image version                                                                    | `2.4`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |
@@ -547,8 +570,8 @@ section of `values.yaml` file:
 | Parameter                          | Description                                                                           | Default                                                                      |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | enabled                            | Deploy the ingress controller, rbac and crd                                           | true                                                                         |
-| image.repository                   | Docker image with the ingress controller                                              | kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller |
-| image.tag                          | Version of the ingress controller                                                     | 0.9.1                                                                        |
+| image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller |
+| image.tag                          | Version of the ingress controller                                                     | 1.2.0 |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
 | installCRDs                        | Creates managed CRDs.                                                                 | false
@@ -572,6 +595,10 @@ For a complete list of all configuration values you can set in the
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
+| deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
+| deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |
+| deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                     |
+| deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                     |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
 | autoscaling.minReplicas            | Set minimum number of replicas                                                        | `2`                 |
 | autoscaling.maxReplicas            | Set maximum number of replicas                                                        | `5`                 |

--- a/helm/kong-app/UPGRADE.md
+++ b/helm/kong-app/UPGRADE.md
@@ -17,6 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [2.1.0](#210)
 - [2.0.0](#200)
 - [1.14.0](#1140)
 - [1.11.0](#1110)
@@ -56,6 +57,19 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 2.1.0
+
+### Migration off Bintray
+
+Bintray, the Docker registry previously used for several images used by this
+chart, is [sunsetting May 1,
+2021](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).
+
+The chart default `values.yaml` now uses the new Docker Hub repositories for all
+affected images. You should check your release `values.yaml` files to confirm that
+they do not still reference Bintray repositories. If they do, update them to
+use the Docker Hub repositories now in the default `values.yaml`.
 
 ## 2.0.0
 

--- a/helm/kong-app/ci/single-image-default.yaml
+++ b/helm/kong-app/ci/single-image-default.yaml
@@ -2,7 +2,7 @@
 # use single image strings instead of repository/tag
 
 image:
-  unifiedRepoTag: kong:2.3
+  unifiedRepoTag: kong:2.4
 proxy:
   type: NodePort
 
@@ -12,5 +12,5 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    unifiedRepoTag: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1.1
+    unifiedRepoTag: kong/kubernetes-ingress-controller:1.2.0
   installCRDs: false

--- a/helm/kong-app/ci/test3-values.yaml
+++ b/helm/kong-app/ci/test3-values.yaml
@@ -28,3 +28,24 @@ dblessConfig:
             message: "dbless-config"
 proxy:
   type: NodePort
+deployment:
+  initContainers:
+    - name: "bash"
+      image: "bash:latest"
+      command: ["/bin/sh", "-c", "true"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "64Mi"
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+      volumeMounts:
+      - name: "tmpdir"
+        mountPath: "/opt/tmp"
+  userDefinedVolumes:
+  - name: "tmpdir"
+    emptyDir: {}
+  userDefinedVolumeMounts:
+  - name: "tmpdir"
+    mountPath: "/opt/tmp"

--- a/helm/kong-app/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/helm/kong-app/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -11,8 +11,8 @@
 #   the Portal and Portal API.
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 env:
   prefix: /kong_prefix/

--- a/helm/kong-app/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/helm/kong-app/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -8,8 +8,8 @@
 # kubectl port-forward deploy/your-deployment-kong 8001:8001 8002:8002
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 admin:
   enabled: true

--- a/helm/kong-app/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/helm/kong-app/example-values/minimal-kong-enterprise-dbless.yaml
@@ -3,8 +3,8 @@
 # Secrets. These Secrets must be created before installation.
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 enterprise:
   enabled: true

--- a/helm/kong-app/requirements.lock
+++ b/helm/kong-app/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.6.8
+digest: sha256:8a3bbab2075144edbd954b95b2c779a61dcc55ec6a858f24b01b1e0031b72c19
+generated: "2020-03-20T13:08:19.76868615-07:00"

--- a/helm/kong-app/templates/deployment.yaml
+++ b/helm/kong-app/templates/deployment.yaml
@@ -1,6 +1,10 @@
 {{- if or .Values.deployment.kong.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
+{{- if .Values.deployment.daemonset }}
+kind: DaemonSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ template "kong.fullname" . }}
   namespace:  {{ template "kong.namespace" . }}
@@ -16,13 +20,19 @@ metadata:
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.deployment.daemonset }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "kong.selectorLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
+  {{- if .Values.deployment.daemonset }}
+  updateStrategy:
+  {{- else }}
   strategy:
+  {{- end }}
 {{ toYaml .Values.updateStrategy | indent 4 }}
   {{- end }}
 
@@ -58,9 +68,14 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
+      {{- if (or (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) .Values.deployment.initContainers) }}
       initContainers:
-      {{- include "kong.wait-for-db" . | nindent 6 }}
+        {{- if .Values.deployment.initContainers }}
+        {{- toYaml .Values.deployment.initContainers | nindent 6 }}
+        {{- end }}
+        {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
+        {{- include "kong.wait-for-db" . | nindent 6 }}
+        {{- end }}
       {{- end }}
       containers:
       {{- if .Values.ingressController.enabled }}
@@ -71,10 +86,10 @@ spec:
       {{- end }}
       {{- if .Values.deployment.kong.enabled }}
       - name: "proxy"
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- if .Values.image.registry }}
+        image: {{ .Values.image.registry }}/{{ include "kong.getRepoTag" .Values.image }}
         {{- else }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "kong.getRepoTag" .Values.image }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
@@ -211,6 +226,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 10 }}
+        {{- include "kong.userDefinedVolumeMounts" . | nindent 10 }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
@@ -237,4 +253,5 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       volumes:
       {{- include "kong.volumes" . | nindent 8 -}}
+      {{- include "kong.userDefinedVolumes" . | nindent 8 -}}
 {{- end }}

--- a/helm/kong-app/templates/migrations-post-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-post-upgrade.yaml
@@ -45,10 +45,10 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- if .Values.image.registry }}
+        image: {{ .Values.image.registry }}/{{ include "kong.getRepoTag" .Values.image }}
         {{- else }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "kong.getRepoTag" .Values.image }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
@@ -63,6 +63,10 @@ spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/helm/kong-app/templates/migrations-pre-upgrade.yaml
+++ b/helm/kong-app/templates/migrations-pre-upgrade.yaml
@@ -45,10 +45,10 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- if .Values.image.registry }}
+        image: {{ .Values.image.registry }}/{{ include "kong.getRepoTag" .Values.image }}
         {{- else }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "kong.getRepoTag" .Values.image }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
@@ -63,6 +63,10 @@ spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/helm/kong-app/templates/migrations.yaml
+++ b/helm/kong-app/templates/migrations.yaml
@@ -53,10 +53,10 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
+        {{- if .Values.image.registry }}
+        image: {{ .Values.image.registry }}/{{ include "kong.getRepoTag" .Values.image }}
         {{- else }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "kong.getRepoTag" .Values.image }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
@@ -71,6 +71,10 @@ spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/helm/kong-app/templates/pdb.yaml
+++ b/helm/kong-app/templates/pdb.yaml
@@ -16,4 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "kong.metaLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
 {{- end }}

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -213,6 +213,9 @@
                 "kong": {
                     "type": "object",
                     "properties": {
+                        "daemonset": {
+                            "type": "boolean"
+                        },
                         "enabled": {
                             "type": "boolean"
                         }

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -19,11 +19,22 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+    # Use a DaemonSet controller instead of a Deployment controller
+    daemonset: false
   ## Optionally specify any extra sidecar containers to be included in the deployment
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
   # sidecarContainers:
   #   - name: sidecar
   #     image: sidecar:latest
+  # initContainers:
+  # - name: initcon
+  #   image: initcon:latest
+  # userDefinedVolumes:
+  # - name: "volumeName"
+  #   emptyDir: {}
+  # userDefinedVolumeMounts:
+  # - name: "volumeName"
+  #   mountPath: "/opt/user/dir/mount"
 
 # Override namepsace for Kong chart resources. By default, the chart creates resources in the release namespace.
 # This may not be desirable when using this chart as a dependency.
@@ -58,10 +69,10 @@ env:
 image:
   registry: quay.io
   repository: giantswarm/kong
-  tag: "2.3.3"
+  tag: "2.4.1"
   # Kong Enterprise
-  # repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  # tag: "2.3.2.0-alpine"
+  # repository: kong/kong-gateway
+  # tag: "2.3.3.2-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -205,7 +216,7 @@ proxy:
     - http2
 
   # Define stream (TCP) listen
-  # To enable, remove "{}", uncomment the section below, and select your desired
+  # To enable, remove "[]", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their servicePort,
   # e.g. "stream-9000" for the below.
   stream: []
@@ -322,7 +333,7 @@ ingressController:
   enabled: true
   image:
     repository: giantswarm/kong-ingress-controller
-    tag: "1.1"
+    tag: "1.2"
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables
@@ -583,6 +594,8 @@ securityContext: {}
 
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created
+  # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
+  # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
   enabled: false
   # interval: 10s
   # Specifies namespace, where ServiceMonitor should be installed


### PR DESCRIPTION
Update the app to align with upstream chart [2.1.0](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#210) which includes updates for kong to [2.4.1](https://github.com/Kong/kong/blob/master/CHANGELOG.md#241) and kong ingress controller [1.2.0](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#120---20210324). For more information check the linked changelogs.