### PR TITLE
Fix lookup for CA secret for admission webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix lookup for CA secret for admission webhook.
+
 ## [2.3.0] - 2021-08-25
 
 ### Breaking Changes

--- a/helm/kong-app/templates/admission-webhook.yaml
+++ b/helm/kong-app/templates/admission-webhook.yaml
@@ -17,6 +17,8 @@
 {{- if $certSecret }}
 {{- $certCert = (b64dec (get $certSecret.data "tls.crt")) -}}
 {{- $certKey = (b64dec (get $certSecret.data "tls.key")) -}}
+{{- end }}
+{{- if $caSecret }}
 {{- $caCert = (b64dec (get $caSecret.data "tls.crt")) -}}
 {{- $caKey = (b64dec (get $caSecret.data "tls.key")) -}}
 {{- end }}


### PR DESCRIPTION
Fixes error when the `validation-webhook-ca-keypair` secret has been deleted but the `validation-webhook-keypair` has not.

```
  reason: 'template: kong-app/templates/admission-webhook.yaml:20:36: executing "kong-app/templates/admission-webhook.yaml"
    at <$caSecret.data>: wrong type for value; expected map[string]interface {}; got
```