### PR TITLE
Restore ingressClass name to original 'kong' name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,6 @@ Ingress Controller
 [documentation](https://github.com/Kong/kubernetes-ingress-controller/tree/master/docs)
 for more detailed explanation and usage.
 
-#### Ingress Controller Class
-The default ingress controller class used by this app is `kong-app`. This
-differs from the upstream default `kong`. We have changed the default, as this
-conflicts with other ingress controllers and the default ingress controller in
-Giant Swarm clusters is `nginx`.
-
-For more details about this please have a look [upstream deployment
-documentation](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md#multiple-ingress-controllers)
-
 ### DBLess Kong
 The [official documentation](https://docs.konghq.com/1.4.x/db-less-and-declarative-config/)
 explains how DBLess Kong works and the possible limitations. To use this method

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -451,11 +451,7 @@ ingressController:
     # caBundle:
     #   | Add the CA bundle content here.
 
-  # This has been changed from the default `kong`
-  # as it allows this app to exist alongside other
-  # ingress controllers, such as nginx which is the
-  # default in the cluster.
-  ingressClass: kong-app
+  ingressClass: kong
   # annotations for IngressClass resource (Kubernetes 1.18+)
   ingressClassAnnotations: {}
 

--- a/tests/ats/test-ingress.yaml
+++ b/tests/ats/test-ingress.yaml
@@ -88,7 +88,7 @@ metadata:
   name: helloworld
   namespace: helloworld
 spec:
-  ingressClassName: kong-app
+  ingressClassName: kong
   rules:
   - host: helloworld
     http:


### PR DESCRIPTION
As discussed, it makes more sense to restore the ingressClass name to its default value (`kong`)