### PR TITLE
Allow empty image.registry in crd install job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixes
+
+- Handle empty `image.registry` in CRD install job
+
 ## [2.7.0] - 2022-02-16
 
 ### Added

--- a/helm/kong-app/templates/crd-install/crd-job.yaml
+++ b/helm/kong-app/templates/crd-install/crd-job.yaml
@@ -21,13 +21,13 @@ spec:
     spec:
       serviceAccountName: {{ template "kong.name.crdInstall" . }}
       securityContext:
-      {{- include "kong.podsecuritycontext" . | nindent 8 }}        
+      {{- include "kong.podsecuritycontext" . | nindent 8 }}
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.image.registry }}/giantswarm/docker-kubectl:1.23.3"
+        image: "{{ .Values.image.registry | default "docker.io" }}/giantswarm/docker-kubectl:1.23.3"
         command:
         - sh
         - -c


### PR DESCRIPTION
This PR is a fix to allow empty `image.registy` in crd install job