### PR TITLE
Add default affinity and topologySpreadConstraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Added team ownership to default labels.
+- Default `affinity` and `topologySpreadConstraints` to make sure pods are spread evenly across zones.
 
 ## [2.7.2] - 2022-03-10
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Giant Swarm offers a Kong Managed App which can be installed in tenant clusters.
 
 | Giant Swarm Chart Release | Upstream Chart Release | Kong Version | Kong IC Version | Kong-Gateway Enterprise container tag |
 | --- | --- | --- | --- | --- |
+| Unreleased | [2.7.0](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#270) | [2.7.1](https://github.com/Kong/kong/blob/master/CHANGELOG.md#271) | [2.2.1](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#221) | 2.7.1.1-alpine |
 | [v2.7.2](https://github.com/giantswarm/kong-app/blob/master/CHANGELOG.md#272---2022-03-10) | [2.7.0](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#270) | [2.7.1](https://github.com/Kong/kong/blob/master/CHANGELOG.md#271) | [2.2.1](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#221) | 2.7.1.1-alpine |
 | [v2.7.1](https://github.com/giantswarm/kong-app/blob/master/CHANGELOG.md#271---2022-02-16) | [2.7.0](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#270) | [2.7.1](https://github.com/Kong/kong/blob/master/CHANGELOG.md#271) | [2.2.1](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#221) | 2.7.1.1-alpine |
 | [v2.7.0](https://github.com/giantswarm/kong-app/blob/master/CHANGELOG.md#270---2022-02-16) | [2.7.0](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#270) | [2.7.1](https://github.com/Kong/kong/blob/master/CHANGELOG.md#271) | [2.2.1](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#221) | 2.7.1.1-alpine |
@@ -42,8 +43,8 @@ This app does not by default provide a database and if a database is required,
 then you will need to BYOD (Bring Your Own Database). For testing purposes, it
 is possible launch postgres alongside this App (described below).
 
-For detailed configuration options, please refer to the [configuration list](helm/kong-app/README.md#configuration)
-also the [`values.yaml` file](helm/kong-app/values.yaml)
+For detailed configuration options, please refer to the [configuration list](https://github.com/giantswarm/kong-app/blob/master/helm/kong-app/README.md#configuration)
+also the [`values.yaml` file](https://github.com/giantswarm/kong-app/blob/master/helm/kong-app/values.yaml)
 
 Any key value put under the `env` section translates to environment variables
 used to control Kong's configuration. Every key is prefixed with KONG_ and
@@ -184,7 +185,7 @@ This is not required for Helm 3, as CRDs will be installed automatically.
 
 ## Automatic and manual testing
 
-The helm chart in this repository undergoes [a series of automated tests](tests/ats/test_basic_cluster.py) running on a [kind](https://kind.sigs.k8s.io/) cluster ([kind cluster config](tests/kind_config.yaml)) executed by [app-test-suite](https://github.com/giantswarm/app-test-suite). ([chart values used for tests](tests/test-values.yaml))
+The helm chart in this repository undergoes [a series of automated tests](https://github.com/giantswarm/kong-app/blob/master/tests/ats/test_basic_cluster.py) running on a [kind](https://kind.sigs.k8s.io/) cluster ([kind cluster config](https://github.com/giantswarm/kong-app/blob/master/tests/kind_config.yaml)) executed by [app-test-suite](https://github.com/giantswarm/app-test-suite). ([chart values used for tests](https://github.com/giantswarm/kong-app/blob/master/tests/test-values.yaml))
 
 Testing includes creation of `Deployment`, `Service`, and `Ingress` resources to check if reconciliation works as intended.
 

--- a/helm/kong-app/README.md
+++ b/helm/kong-app/README.md
@@ -655,8 +655,8 @@ For a complete list of all configuration values you can set in the
 | livenessProbe                      | Kong liveness probe                                                                   |                     |
 | lifecycle                          | Proxy container lifecycle hooks                                                       | see `values.yaml`   |
 | terminationGracePeriodSeconds      | Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pods | 30                  |
-| affinity                           | Node/pod affinities                                                                   |                     |
-| topologySpreadConstraints          | Control how Pods are spread across cluster among failure-domains                      |                     |
+| affinity                           | Node/pod affinities                                                                   |  see `values.yaml`  |
+| topologySpreadConstraints          | Control how Pods are spread across cluster among failure-domains. We suggest to review the `values.yaml` and [documentation](https://docs.giantswarm.io/advanced/high-availability/multi-az/) |  see `values.yaml`  |
 | nodeSelector                       | Node labels for pod assignment                                                        | `{}`                |
 | deploymentAnnotations              | Annotations to add to deployment                                                      |  see `values.yaml`  |
 | podAnnotations                     | Annotations to add to each pod                                                        | `{}`                |

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -25,6 +25,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kong.imagesHash" -}}
+{{- if .Values.image.registry }}
+{{- printf "%s-%s-%s" .Values.image.registry (include "kong.getRepoTag" .Values.image) (include "kong.getRepoTag" .Values.ingressController.image) | sha256sum -}}
+{{- else }}
+{{- printf "%s-%s" (include "kong.getRepoTag" .Values.image) (include "kong.getRepoTag" .Values.ingressController.image) | sha256sum -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "kong.metaLabels" -}}
 app.kubernetes.io/name: {{ template "kong.name" . }}
 helm.sh/chart: {{ template "kong.chart" . }}
@@ -32,6 +40,7 @@ app.kubernetes.io/instance: "{{ .Release.Name }}"
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/container-images-hash: {{ include "kong.imagesHash" . | quote }}
 {{- range $key, $value := .Values.extraLabels }}
 {{ $key }}: {{ $value | quote }}
 {{- end }}

--- a/helm/kong-app/templates/_helpers.tpl
+++ b/helm/kong-app/templates/_helpers.tpl
@@ -27,9 +27,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "kong.imagesHash" -}}
 {{- if .Values.image.registry }}
-{{- printf "%s-%s-%s" .Values.image.registry (include "kong.getRepoTag" .Values.image) (include "kong.getRepoTag" .Values.ingressController.image) | sha256sum -}}
+{{- printf "%s-%s-%s" .Values.image.registry (include "kong.getRepoTag" .Values.image) (include "kong.getRepoTag" .Values.ingressController.image) | sha256sum | trunc 63 -}}
 {{- else }}
-{{- printf "%s-%s" (include "kong.getRepoTag" .Values.image) (include "kong.getRepoTag" .Values.ingressController.image) | sha256sum -}}
+{{- printf "%s-%s" (include "kong.getRepoTag" .Values.image) (include "kong.getRepoTag" .Values.ingressController.image) | sha256sum | trunc 63 -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/kong-app/templates/deployment.yaml
+++ b/helm/kong-app/templates/deployment.yaml
@@ -283,7 +283,7 @@ spec:
     {{- end }}
     {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+{{ tpl .Values.topologySpreadConstraints . | indent 6 }}
     {{- end }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -76,6 +76,49 @@
                 }
             }
         },
+        "affinity": {
+            "type": "object",
+            "properties": {
+                "nodeAffinity": {
+                    "type": "object",
+                    "properties": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "object",
+                            "properties": {
+                                "nodeSelectorTerms": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "matchExpressions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "key": {
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "type": "string"
+                                                        },
+                                                        "values": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "autoscaling": {
             "type": "object",
             "properties": {
@@ -193,6 +236,52 @@
         },
         "containerSecurityContext": {
             "type": "object"
+        },
+        "crds": {
+            "type": "object",
+            "properties": {
+                "backoffLimit": {
+                    "type": "integer"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "install": {
+                    "type": "boolean"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "dblessConfig": {
             "type": "object",
@@ -1238,6 +1327,9 @@
         },
         "tolerations": {
             "type": "array"
+        },
+        "topologySpreadConstraints": {
+            "type": "string"
         },
         "udpProxy": {
             "type": "object",

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -620,7 +620,12 @@ affinity:
           operator: NotIn
           values:
           - master
-          - controlplane
+      - matchExpressions:
+        - key: node-role.kubernetes.io/master
+          operator: DoesNotExist
+      - matchExpressions:
+        - key: node-role.kubernetes.io/control-plane
+          operator: DoesNotExist
 
 # Topology spread constraints for pod assignment (requires Kubernetes >= 1.19)
 # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -629,6 +629,8 @@ affinity:
 
 # Topology spread constraints for pod assignment (requires Kubernetes >= 1.19)
 # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+# Important: We strongly suggest you review these settings before applying onto your clusters.
+# Document https://docs.giantswarm.io/advanced/high-availability/multi-az/ gives more insight.
 topologySpreadConstraints: |-
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -611,11 +611,34 @@ terminationGracePeriodSeconds: 30
 
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-# affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/role
+          operator: NotIn
+          values:
+          - master
+          - controlplane
 
 # Topology spread constraints for pod assignment (requires Kubernetes >= 1.19)
 # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
-# topologySpreadConstraints: []
+topologySpreadConstraints: |-
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: {{ template "kong.name" . }}
+        application.giantswarm.io/container-images-hash: {{ include "kong.imagesHash" . | quote }}
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: {{ template "kong.name" . }}
+        application.giantswarm.io/container-images-hash: {{ include "kong.imagesHash" . | quote }}
 
 # Tolerations for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -632,7 +632,7 @@ affinity:
 topologySpreadConstraints: |-
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: DoNotSchedule
+    whenUnsatisfiable: ScheduleAnyway
     labelSelector:
       matchLabels:
         app.kubernetes.io/name: {{ template "kong.name" . }}

--- a/tests/kind_config.yaml
+++ b/tests/kind_config.yaml
@@ -7,7 +7,7 @@ nodes:
     kind: InitConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
+        node-labels: "ingress-ready=true,topology.kubernetes.io/zone=cool-zone"
   extraPortMappings:
   - containerPort: 32080
     hostPort: 8080

--- a/tests/kind_config.yaml
+++ b/tests/kind_config.yaml
@@ -7,7 +7,7 @@ nodes:
     kind: InitConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        node-labels: "ingress-ready=true,topology.kubernetes.io/zone=cool-zone"
+        node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 32080
     hostPort: 8080


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21426

This PR adds `affinity` and `topologySpreadConstraints` to make sure pods are spread evenly across zones.

<!--
Please update after a release:
- the version matrix in README.md
- the kong-gateway tag in tests/test-values-enterprise.yaml
-->

This PR...

## Checklist

- [x] Automated test are working
- [x] Changelog entry has been added

### Manual tests on workload clusters

Played around with multiple zones, changing number of replicas, changing number of zones
