### PR TITLE
Enable PodDisruptionBudget by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Updates
 
 - Enable PodDisruptionBudget to require at least one pod running.
+- Increase default replica count to two.
 
 ## [2.9.0] - 2022-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Enable PodDisruptionBudget to require at least one pod running.
 - Increase default replica count to two.
+- Change default affinity to prevent scheduling on the same node.
 
 ## [2.9.0] - 2022-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Updates
+
+- Enable PodDisruptionBudget to require at least one pod running.
+
 ## [2.9.0] - 2022-04-14
 
 ### Updates

--- a/helm/kong-app/templates/deployment.yaml
+++ b/helm/kong-app/templates/deployment.yaml
@@ -279,7 +279,7 @@ spec:
         {{- end }} {{/* End of Kong container spec */}}
     {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ tpl .Values.affinity . | indent 8 }}
     {{- end }}
     {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -80,47 +80,7 @@
             }
         },
         "affinity": {
-            "type": "object",
-            "properties": {
-                "nodeAffinity": {
-                    "type": "object",
-                    "properties": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": {
-                            "type": "object",
-                            "properties": {
-                                "nodeSelectorTerms": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "matchExpressions": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string"
-                                                        },
-                                                        "operator": {
-                                                            "type": "string"
-                                                        },
-                                                        "values": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            "type": "string"
         },
         "autoscaling": {
             "type": "object",

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -658,7 +658,22 @@ terminationGracePeriodSeconds: 30
 
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-affinity:
+affinity: |-
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - {{ include "kong.chart-name" . | quote }}
+          - key: app.kubernetes.io/instance
+            operator: In
+            values:
+            - {{ .Release.Name | quote }}
+        topologyKey: kubernetes.io/hostname
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -710,7 +710,7 @@ podLabels: {}
 
 # Kong pod count.
 # It has no effect when autoscaling.enabled is set to true
-replicaCount: 1
+replicaCount: 2
 
 # Annotations to be added to Kong deployment
 deploymentAnnotations: {}

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -736,9 +736,9 @@ autoscaling:
 
 # Kong Pod Disruption Budget
 podDisruptionBudget:
-  enabled: false
+  enabled: true
   # Uncomment only one of the following when enabled is set to true
-  # maxUnavailable: "50%"
+  maxUnavailable: "1"
   # minAvailable: "50%"
 
 podSecurityPolicy:

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 deployment_name = "kong-app-kong-app"
 namespace_name = "kong"
 
-timeout: int = 360
+timeout: int = 560
 
 
 @pytest.mark.smoke
@@ -63,7 +63,7 @@ def ic_deployment(request, kube_cluster: Cluster) -> List[pykube.Deployment]:
 
     kube_cluster.kubectl(
         "rollout status --watch statefulset/postgres",
-        timeout="60s",
+        timeout="90s",
         output_format="",
         namespace="postgres",
     )

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -91,7 +91,7 @@ def wait_for_ic_deployment(kube_cluster: Cluster) -> List[pykube.Deployment]:
 @pytest.mark.flaky(reruns=5, reruns_delay=10)
 def test_pods_available(kube_cluster: Cluster, ic_deployment: List[pykube.Deployment]):
     for s in ic_deployment:
-        assert int(s.obj["status"]["readyReplicas"]) > 0
+        assert int(s.obj["status"]["readyReplicas"]) == int(s.obj["spec"]["replicas"])
 
 
 def try_ingress():
@@ -155,7 +155,7 @@ def test_ingress_creation(
     )
 
     # is it even available?
-    assert try_ingress()
+    # assert try_ingress()
 
     # test some plugins
     # we're not testing every plugin

--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -155,7 +155,7 @@ def test_ingress_creation(
     )
 
     # is it even available?
-    # assert try_ingress()
+    assert try_ingress()
 
     # test some plugins
     # we're not testing every plugin

--- a/tests/kind_config.yaml
+++ b/tests/kind_config.yaml
@@ -11,7 +11,7 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 32080
-    hostPort: 8080
+    hostPort: 8081
     listenAddress: "127.0.0.1"
     protocol: TCP
 - role: worker
@@ -24,6 +24,6 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 32080
-    hostPort: 8081
+    hostPort: 8080
     listenAddress: "127.0.0.1"
     protocol: TCP

--- a/tests/kind_config.yaml
+++ b/tests/kind_config.yaml
@@ -2,6 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: quay.io/giantswarm/kind-node-image:kong-2.9.0
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -14,6 +15,7 @@ nodes:
     listenAddress: "127.0.0.1"
     protocol: TCP
 - role: worker
+  image: quay.io/giantswarm/kind-node-image:kong-2.9.0
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/tests/kind_config.yaml
+++ b/tests/kind_config.yaml
@@ -13,3 +13,15 @@ nodes:
     hostPort: 8080
     listenAddress: "127.0.0.1"
     protocol: TCP
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 32080
+    hostPort: 8081
+    listenAddress: "127.0.0.1"
+    protocol: TCP

--- a/tests/kind_config.yaml
+++ b/tests/kind_config.yaml
@@ -3,6 +3,8 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   image: quay.io/giantswarm/kind-node-image:kong-2.9.0
+- role: worker
+  image: quay.io/giantswarm/kind-node-image:kong-2.9.0
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -11,7 +13,7 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 32080
-    hostPort: 8081
+    hostPort: 8080
     listenAddress: "127.0.0.1"
     protocol: TCP
 - role: worker
@@ -24,6 +26,6 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 32080
-    hostPort: 8080
+    hostPort: 8081
     listenAddress: "127.0.0.1"
     protocol: TCP


### PR DESCRIPTION
<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

<!--
Please update after a release:
- the version matrix in README.md
- the kong-gateway tag in tests/test-values-enterprise.yaml
-->

This PR changes the defaul values to enable PodDisruptionBudget by default.

## Checklist

- [x] Automated test are working (for chart changes)
- [x] Changelog entry has been added

### Manual tests on workload clusters

For plain installations (default values) and database mode (deploy `tests/manual/postgres.yaml`, then install with `tests/manual/values-database.yaml`), execute these tests. If you have additional configuration, make sure your existing deployments with custom values still work.

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
