### PR TITLE
Update kubectl container image + fix missing registry for initContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Updates
+
+- Update kubectl container image to 1.24.2 in CRD install job.
+
+### Fixes
+
+- Make sure all container images use the same container registry.
+
 ## [2.10.0] - 2022-06-02
 
 ### Updates

--- a/helm/kong-app/templates/crd-install/crd-job.yaml
+++ b/helm/kong-app/templates/crd-install/crd-job.yaml
@@ -29,7 +29,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.image.registry | default "docker.io" }}/giantswarm/docker-kubectl:1.23.3"
+        image: "{{ .Values.image.registry | default "docker.io" }}/giantswarm/docker-kubectl:1.24.2"
         command:
         - sh
         - -c

--- a/helm/kong-app/templates/deployment.yaml
+++ b/helm/kong-app/templates/deployment.yaml
@@ -82,7 +82,11 @@ spec:
       {{- end }}
       initContainers:
       - name: clear-stale-pid
+        {{- if .Values.image.registry }}
+        image: {{ .Values.image.registry }}/{{ include "kong.getRepoTag" .Values.image }}
+        {{- else }}
         image: {{ include "kong.getRepoTag" .Values.image }}
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }}


### PR DESCRIPTION
This PR addresses two things:

- Update the kubectl container to 1.24.2 in the CRD install job
- Make sure all containers image references use the same registry
