### PR TITLE
Ingress controller metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Service for scraping metrics from ingress controller
+
 ### Updates
 
 - Align with upstream chart version [2.13.0](https://github.com/Kong/charts/releases/tag/kong-2.13.0) ([Changes in upstream repository](https://github.com/Kong/charts/compare/kong-2.11.0...kong-2.13.0)). Please note this release does not contain kong 3.0.0 yet.

--- a/helm/kong-app/templates/service-kong-metrics.yaml
+++ b/helm/kong-app/templates/service-kong-metrics.yaml
@@ -9,4 +9,17 @@
 {{- $_ := set $serviceConfig "serviceName" "metrics" -}}
 {{- include "kong.service" $serviceConfig }}
 {{- end -}}
+{{- end }}
+---
+{{ if and .Values.ingressController.enabled }}
+{{- $tls := dict "enabled" false -}}
+{{- $http := dict "enabled" true "servicePort" 10255 "containerPort" "cmetrics" -}}
+{{- $annotations := dict "giantswarm.io/monitoring" "true" "giantswarm.io/monitoring-app-label" "kong-app" "giantswarm.io/monitoring-port" "10255" -}}
+{{- $serviceConfig := dict "annotations" $annotations "http" $http "tls" $tls "type" "ClusterIP" -}}
+{{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
+{{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
+{{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
+{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- $_ := set $serviceConfig "serviceName" "ingress-controller-metrics" -}}
+{{- include "kong.service" $serviceConfig }}
 {{- end -}}


### PR DESCRIPTION
This PR adds a Service with Giant Swarm monitoring annotations to enable scraping of metrics from the ingress-controller container.

## Checklist

- [x] Automated test are working (for chart changes)
- [x] Changelog entry has been added
