### PR TITLE
Do not enable custom Giant Swarm monitoring Service if ServiceMonitor is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changes
+
+- Do not enable custom Giant Swarm monitoring Service if ServiceMonitor is enabled.
+
 ## [3.2.0] - 2023-05-04
 
 ### Changes

--- a/helm/kong-app/templates/service-kong-metrics.yaml
+++ b/helm/kong-app/templates/service-kong-metrics.yaml
@@ -4,7 +4,7 @@ This file contains Giant Swarm specific Services for monitoring not present
 in the original upstream chart.
 */}}
 
-{{- if and .Values.deployment.kong.enabled }}
+{{- if and .Values.deployment.kong.enabled (not .Values.serviceMonitor.enabled) }}
 {{- if and .Values.status.enabled (or .Values.status.http.enabled .Values.status.tls.enabled) -}}
 {{- $tls := dict "enabled" false "servicePort" .Values.status.tls.containerPort "containerPort" "status" -}}
 {{- $http := dict "enabled" true "servicePort" .Values.status.http.containerPort "containerPort" "status" -}}
@@ -21,7 +21,7 @@ in the original upstream chart.
 {{- end -}}
 {{- end }}
 ---
-{{ if and .Values.ingressController.enabled }}
+{{ if and .Values.ingressController.enabled (not .Values.serviceMonitor.enabled) }}
 {{- $tls := dict "enabled" false -}}
 {{- $http := dict "enabled" true "servicePort" 10255 "containerPort" "cmetrics" -}}
 {{- $annotations := dict "giantswarm.io/monitoring" "true" "giantswarm.io/monitoring-app-label" "kong-app" "giantswarm.io/monitoring-port" "10255" -}}

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Merge branch 'upstream-main'
-      sha: 05ac30717213dbd9759eebb3554af96f681bebde
+      commitTitle: Do not create metrics services if ServiceMonitor is enabled (#13)
+      sha: ee282af2c229ecee593bbe9aee7658a5991eeb29
       tags:
-      - kong-2.20.1-53-g05ac307
+      - kong-2.20.1-54-gee282af
     path: kong
   path: vendor
 - contents:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26954

This PR disables rendering custom Giant Swarm monitoring Services if built in ServiceMonitor is enabled.


