### PR TITLE
ignore linkerd namespace in ValidatingWebhookConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Do not enable custom Giant Swarm monitoring Service if ServiceMonitor is enabled.
 - Align with upstream chart version [2.21.0](https://github.com/Kong/charts/releases/tag/kong-2.21.0) ([Changes in upstream repository](https://github.com/Kong/charts/compare/kong-2.20.1...kong-2.21.0))
+- Ignore linkerd namespace in ValidatingWebhookConfiguration.
 
 ## [3.2.0] - 2023-05-04
 

--- a/helm/kong-app/values.schema.json
+++ b/helm/kong-app/values.schema.json
@@ -657,6 +657,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "namespaceSelector": {
+                            "type": "object"
+                        },
                         "failurePolicy": {
                             "type": "string"
                         },

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -535,6 +535,12 @@ ingressController:
     port: 8080
     certificate:
       provided: false
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - linkerd
     # Specifiy the secretName when the certificate is provided via a TLS secret
     # secretName: ""
     # Specifiy the CA bundle of the provided certificate.


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

<!--
Please update after a release:
- the version matrix in README.md
- the kong-gateway tag in tests/test-values-enterprise.yaml
-->

This PR ignores by default the linkerd namespace in the ValidatingWebhookConfigurations

It requires sync with the upstream chart for it to work. 

Towards https://github.com/giantswarm/giantswarm/issues/24914

## Checklist

- [ ] Automated test are working (for chart changes)
- [ ] Changelog entry has been added

### Manual tests on workload clusters

For plain installations (default values) and database mode (deploy `tests/manual/postgres.yaml`, then install with `tests/manual/values-database.yaml`), execute these tests. If you have additional configuration, make sure your existing deployments with custom values still work.

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
