### PR TITLE
Adopt gsoci.azurecr.io oci registry

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -4,6 +4,5 @@ chart-dir: ./helm/kong-app
 destination: ./build
 # CI overwrites this, check .circleci/config.yaml
 catalog-base-url: https://giantswarm.github.io/giantswarm-catalog/
-ct-config: ./.circleci/ct-config.yaml
 # until we support custom template helper filenames
 disable-giantswarm-helm-validator: true

--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,5 +1,0 @@
----
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
-  - giantswarm-playground-catalog=https://giantswarm.github.io/giantswarm-playground-catalog
-  - giantswarm-playground-test-catalog=https://giantswarm.github.io/giantswarm-playground-test-catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changes
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [3.6.1] - 2023-12-11
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changes
 
 - Configure `gsoci.azurecr.io` as the default container image registry.
+- Update kubectl-apply-job to 0.7.0 for `gsoci.azurecr.io` container image registry.
 
 ## [3.6.1] - 2023-12-11
 

--- a/helm/kong-app/Chart.lock
+++ b/helm/kong-app/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.9.13
 - name: kubectl-apply-job
-  repository: https://giantswarm.github.io/giantswarm-playground-catalog
-  version: 0.6.0
-digest: sha256:0c2d305422eab215a4c44a89c0e4cfba43fd2fcd89a53d3ef992dfa9526c127d
-generated: "2023-10-05T16:27:58.100212305+02:00"
+  repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog
+  version: 0.7.0
+digest: sha256:c35a500c2ec10abc78325ed89588b3416de166d2f786ff572c9824fd3c7557a2
+generated: "2023-12-12T16:34:22.530811904+01:00"

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -20,8 +20,8 @@ kubeVersion: ">=1.22.0-0"
 dependencies:
   - name: postgresql
     version: 11.9.13
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: kubectl-apply-job
-    version: "0.6.0"
-    repository: https://giantswarm.github.io/giantswarm-playground-catalog
+    version: "0.7.0"
+    repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -125,7 +125,7 @@ extraLabels: {}
 
 # Specify Kong's Docker image and repository details here
 image:
-  registry: &registry quay.io
+  registry: &registry gsoci.azurecr.io
   repository: giantswarm/kong
   tag: "3.5.0"
   # Kong Enterprise


### PR DESCRIPTION
This PR switches the default image registry to use gsoci.azurecr.io https://github.com/giantswarm/roadmap/issues/3040

## Checklist

- [x] Automated test are working (for chart changes)
- [x] Changelog entry has been added
