### PR TITLE
Set read only root fs for CRD install job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,37 +19,6 @@ workflows:
             tags:
               only: /^v.*/
 
-      # Require manual approval for running oss tests
-      - hold-tests:
-          name: hold OSS tests
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - main
-            tags:
-              ignore: /^v.*/
-
-      - architect/run-tests-with-ats:
-          name: execute enterprise tests
-          additional_app-test-suite_flags: "--app-tests-app-config-file=tests/test-values-enterprise.yaml"
-          filters:
-            branches:
-              ignore:
-                - main
-          requires:
-            - push-to-giantswarm-app-catalog
-
-      - architect/run-tests-with-ats:
-          name: execute enterprise tests (1.25)
-          additional_app-test-suite_flags: "--app-tests-app-config-file=tests/test-values-enterprise.yaml --kind-cluster-image=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
-          filters:
-            branches:
-              ignore:
-                - main
-          requires:
-            - push-to-giantswarm-app-catalog
-      
       - architect/run-tests-with-ats:
           name: execute chart tests
           filters:
@@ -57,7 +26,6 @@ workflows:
               ignore:
                 - main
           requires:
-            - hold OSS tests
             - push-to-giantswarm-app-catalog
 
       - architect/run-tests-with-ats:
@@ -68,5 +36,37 @@ workflows:
               ignore:
                 - main
           requires:
-            - hold OSS tests
+            - push-to-giantswarm-app-catalog
+
+      # Require manual approval for running enterprise tests
+      - hold-tests:
+          name: hold enterprise tests
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - main
+            tags:
+              ignore: /^v.*/
+
+      - architect/run-tests-with-ats:
+          name: execute enterprise tests (1.25)
+          additional_app-test-suite_flags: "--app-tests-app-config-file=tests/test-values-enterprise.yaml"
+          filters:
+            branches:
+              ignore:
+                - master
+          requires:
+            - hold enterprise tests
+            - push-to-giantswarm-app-catalog
+
+      - architect/run-tests-with-ats:
+          name: execute enterprise tests
+          additional_app-test-suite_flags: "--app-tests-app-config-file=tests/test-values-enterprise.yaml --kind-cluster-image=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
+          filters:
+            branches:
+              ignore:
+                - main
+          requires:
+            - hold enterprise tests
             - push-to-giantswarm-app-catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changes
+
+- Update kubectl-apply-job to 0.8.0 for enabling `readOnlyRootFilesystem: true` for kubectl CRD install job container.
+
 ## [3.7.0] - 2024-01-16
 
 ### Changes

--- a/helm/kong-app/Chart.lock
+++ b/helm/kong-app/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.9.13
 - name: kubectl-apply-job
-  repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog
-  version: 0.7.0
-digest: sha256:c35a500c2ec10abc78325ed89588b3416de166d2f786ff572c9824fd3c7557a2
-generated: "2023-12-12T16:34:22.530811904+01:00"
+  repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-test-catalog
+  version: 0.7.0-40b7e80ebbb6aaee38cd405cf42ae290bf26d29e
+digest: sha256:a1448f8a7e7979fd8d1ddf7bcaa598df28be4171898e67ae2ee7dc1c8ba38bf1
+generated: "2024-07-08T14:20:24.279467618+02:00"

--- a/helm/kong-app/Chart.lock
+++ b/helm/kong-app/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.9.13
 - name: kubectl-apply-job
-  repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-test-catalog
-  version: 0.7.0-40b7e80ebbb6aaee38cd405cf42ae290bf26d29e
-digest: sha256:a1448f8a7e7979fd8d1ddf7bcaa598df28be4171898e67ae2ee7dc1c8ba38bf1
-generated: "2024-07-08T14:20:24.279467618+02:00"
+  repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog
+  version: 0.8.0
+digest: sha256:e51bb892e434a9e518083a7fbe8944ccf709c269e91e7e7719b02955834c0c7c
+generated: "2024-07-08T15:09:04.741475082+02:00"

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -23,5 +23,5 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: kubectl-apply-job
-    version: "0.7.0"
-    repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog
+    version: "0.7.0-40b7e80ebbb6aaee38cd405cf42ae290bf26d29e"
+    repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-test-catalog

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -23,5 +23,5 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: kubectl-apply-job
-    version: "0.7.0-40b7e80ebbb6aaee38cd405cf42ae290bf26d29e"
-    repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-test-catalog
+    version: "0.8.0"
+    repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog


### PR DESCRIPTION
This PR updates the kubectl-apply-job chart dependency to [v0.8.0](https://github.com/giantswarm/kubectl-apply-job/releases/tag/v0.8.0) which sets `readOnlyRootFilesystem: true` for the kubectl container.

Note for reviewers: Ignore the tests in CI, not sure whats going on but this is working on a live GS cluster
