### PR TITLE
Revert admissionWebhook config to upstream defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Update kong ingress controller to [3.3.1](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#331)
 - Align with upstream chart version [2.42.0](https://github.com/Kong/charts/releases/tag/kong-2.42.0) ([Changes in upstream repository](https://github.com/Kong/charts/compare/kong-2.40.0...kong-2.42.0))
+- Revert `ingressController.admissionWebhook` settings to upstream values. (Enabled by default with `failurePolicy: Ignore`)
 
 ## [4.4.0] - 2024-08-19
 

--- a/diffs/helm__kong-app__values.yaml.patch
+++ b/diffs/helm__kong-app__values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/kong/charts/kong/values.yaml b/helm/kong-app/values.yaml
-index cc8a8b2..ffdd7e8 100644
+index cc8a8b2..4b02c35 100644
 --- a/vendor/kong/charts/kong/values.yaml
 +++ b/helm/kong-app/values.yaml
 @@ -91,6 +91,7 @@ deployment:
@@ -47,15 +47,7 @@ index cc8a8b2..ffdd7e8 100644
      # The controller disables TLS verification by default because Kong
      # generates self-signed certificates by default. Set this to false once you
      # have installed CA-signed certificates.
-@@ -585,13 +589,18 @@ ingressController:
- 
-   admissionWebhook:
-     matchPolicy: Equivalent
--    enabled: true
-+    enabled: false
-     filterSecrets: false
--    failurePolicy: Ignore
-+    failurePolicy: Fail
+@@ -591,7 +595,12 @@ ingressController:
      port: 8080
      certificate:
        provided: false

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -589,9 +589,9 @@ ingressController:
 
   admissionWebhook:
     matchPolicy: Equivalent
-    enabled: false
+    enabled: true
     filterSecrets: false
-    failurePolicy: Fail
+    failurePolicy: Ignore
     port: 8080
     certificate:
       provided: false

--- a/sync/patches/values-schema/values.yaml.patch
+++ b/sync/patches/values-schema/values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git b/helm/kong-app/values.yaml a/helm/kong-app/values.yaml
-index cc8a8b2..ffdd7e8 100644
+index cc8a8b2..4b02c35 100644
 --- b/helm/kong-app/values.yaml
 +++ a/helm/kong-app/values.yaml
 @@ -91,6 +91,7 @@ deployment:
@@ -47,15 +47,7 @@ index cc8a8b2..ffdd7e8 100644
      # The controller disables TLS verification by default because Kong
      # generates self-signed certificates by default. Set this to false once you
      # have installed CA-signed certificates.
-@@ -585,13 +589,18 @@ ingressController:
- 
-   admissionWebhook:
-     matchPolicy: Equivalent
--    enabled: true
-+    enabled: false
-     filterSecrets: false
--    failurePolicy: Ignore
-+    failurePolicy: Fail
+@@ -591,7 +595,12 @@ ingressController:
      port: 8080
      certificate:
        provided: false


### PR DESCRIPTION
This PR reverts the `ingressController.admissionWebhook.failurePolicy` to upstream default. Kong caused some problems during node rolling

## Checklist

- [x] Automated test are working (for chart changes)
- [x] Changelog entry has been added
