### PR TITLE
Update test values, use 3.8.0 in OSS tests

### DIFF
--- a/tests/test-values-enterprise.yaml
+++ b/tests/test-values-enterprise.yaml
@@ -33,8 +33,6 @@ env:
 
 ingressController:
   ingressClass: kong
-  admissionWebhook:
-    enabled: true
   env:
     anonymous_reports: "false"
     proxy_sync_seconds: "30"

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -18,14 +18,12 @@ env:
 
 image:
   repository: giantswarm/kong
-  tag: "3.7.1"
+  tag: "3.8.0"
 
 enterprise:
   enabled: false
 ingressController:
   ingressClass: kong
-  admissionWebhook:
-    enabled: true
   env:
     anonymous_reports: "false"
   installCRDs: false


### PR DESCRIPTION
<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

<!--
Please update after a release:
- the version matrix in README.md
- the kong-gateway tag in tests/test-values-enterprise.yaml
-->

This PR updates the kong test values

## Checklist

- [ ] Automated test are working (for chart changes)
- [ ] Changelog entry has been added

### Manual tests on workload clusters

For plain installations (default values) and database mode (deploy `tests/manual/postgres.yaml`, then install with `tests/manual/values-database.yaml`), execute these tests. If you have additional configuration, make sure your existing deployments with custom values still work.

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
