### PR TITLE
make VPA resource more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make VPA resource more flexible: `updateMode`, `controlledValues`, and `mode` are now configurable per container group; `maxAllowed` is supported for both proxy and controller containers.
+
 ## [5.2.1] - 2026-03-04
 
 ### Changed

--- a/diffs/helm__kong-app__values.yaml.patch
+++ b/diffs/helm__kong-app__values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/kong/charts/kong/values.yaml b/helm/kong-app/values.yaml
-index 4013d36..2994007 100644
+index 4013d36..48157c0 100644
 --- a/vendor/kong/charts/kong/values.yaml
 +++ b/helm/kong-app/values.yaml
 @@ -91,6 +91,7 @@ deployment:
@@ -209,7 +209,7 @@ index 4013d36..2994007 100644
  
  # Annotations to be added to Kong deployment
  deploymentAnnotations: {}
-@@ -993,11 +1037,24 @@ autoscaling:
+@@ -993,11 +1037,37 @@ autoscaling:
            type: Utilization
            averageUtilization: 80
  
@@ -218,13 +218,26 @@ index 4013d36..2994007 100644
 +# "resources" and, if using the controller, "ingressController.resources" in values.yaml
 +verticalPodAutoscaler:
 +  enabled: false
++  # updateMode controls when VPA applies resource recommendations.
++  # Allowed values: Auto, Recreate, Initial, Off
++  updateMode: Auto
 +  proxy:
++    # mode controls whether VPA is active for proxy containers. Allowed values: Auto, Off
++    mode: Auto
++    # controlledValues specifies which resource values are controlled. Allowed values: RequestsAndLimits, RequestsOnly
++    controlledValues: RequestsAndLimits
 +    minAllowed:
 +      cpu: 250m
 +      memory: 256Mi
++    # maxAllowed: {}
 +  controller:
++    # mode controls whether VPA is active for the ingress controller container. Allowed values: Auto, Off
++    mode: Auto
++    # controlledValues specifies which resource values are controlled. Allowed values: RequestsAndLimits, RequestsOnly
++    controlledValues: RequestsAndLimits
 +    minAllowed:
 +      cpu: 100m
++    # maxAllowed: {}
 +
  # Kong Pod Disruption Budget
  podDisruptionBudget:
@@ -236,7 +249,7 @@ index 4013d36..2994007 100644
    # minAvailable: "50%"
    unhealthyPodEvictionPolicy: IfHealthyBudget
  
-@@ -1069,9 +1126,9 @@ serviceMonitor:
+@@ -1069,9 +1139,9 @@ serviceMonitor:
    # Specifies whether ServiceMonitor for Prometheus operator should be created
    # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
    # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
@@ -248,7 +261,7 @@ index 4013d36..2994007 100644
    # Specifies namespace, where ServiceMonitor should be installed
    # namespace: monitoring
    # labels:
-@@ -1081,7 +1138,15 @@ serviceMonitor:
+@@ -1081,7 +1151,15 @@ serviceMonitor:
  
    # honorLabels: false
    # metricRelabelings: []
@@ -265,7 +278,7 @@ index 4013d36..2994007 100644
  
  # -----------------------------------------------------------------------------
  # Kong Enterprise parameters
-@@ -1332,3 +1397,10 @@ extraObjects: []
+@@ -1332,3 +1410,10 @@ extraObjects: []
  #   config:
  #     per_consumer: false
  #   plugin: prometheus

--- a/diffs/helm__kong-app__values.yaml.patch
+++ b/diffs/helm__kong-app__values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/kong/charts/kong/values.yaml b/helm/kong-app/values.yaml
-index 4013d36..48157c0 100644
+index 4013d36..4eaac4d 100644
 --- a/vendor/kong/charts/kong/values.yaml
 +++ b/helm/kong-app/values.yaml
 @@ -91,6 +91,7 @@ deployment:
@@ -219,7 +219,7 @@ index 4013d36..48157c0 100644
 +verticalPodAutoscaler:
 +  enabled: false
 +  # updateMode controls when VPA applies resource recommendations.
-+  # Allowed values: Auto, Recreate, Initial, Off
++  # Allowed values: Off, Initial, Recreate, InPlaceOrRecreate, Auto
 +  updateMode: Auto
 +  proxy:
 +    # mode controls whether VPA is active for proxy containers. Allowed values: Auto, Off

--- a/helm/kong-app/templates/vpa.yaml
+++ b/helm/kong-app/templates/vpa.yaml
@@ -13,31 +13,43 @@ spec:
     containerPolicies:
     {{- if .Values.deployment.kong.enabled }}
     - containerName: proxy
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.proxy.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.proxy.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.proxy.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.proxy.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     - containerName: clear-stale-pid
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.proxy.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.proxy.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.proxy.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.proxy.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
     - containerName: wait-for-db
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.proxy.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.proxy.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.proxy.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.proxy.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- end }}
     {{- if .Values.ingressController.enabled }}
     - containerName: ingress-controller
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.controller.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.controller.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.controller.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.controller.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
   targetRef:
     apiVersion: apps/v1
     kind: {{ ternary "DaemonSet" "Deployment" .Values.deployment.daemonset }}
     name: {{ template "kong.fullname" . }}
   updatePolicy:
-    updateMode: Auto
+    updateMode: {{ .Values.verticalPodAutoscaler.updateMode }}
 {{- end }}
 {{- end }}

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -1043,7 +1043,7 @@ autoscaling:
 verticalPodAutoscaler:
   enabled: false
   # updateMode controls when VPA applies resource recommendations.
-  # Allowed values: Auto, Recreate, Initial, Off
+  # Allowed values: Off, Initial, Recreate, InPlaceOrRecreate, Auto
   updateMode: Auto
   proxy:
     # mode controls whether VPA is active for proxy containers. Allowed values: Auto, Off

--- a/helm/kong-app/values.yaml
+++ b/helm/kong-app/values.yaml
@@ -1042,13 +1042,26 @@ autoscaling:
 # "resources" and, if using the controller, "ingressController.resources" in values.yaml
 verticalPodAutoscaler:
   enabled: false
+  # updateMode controls when VPA applies resource recommendations.
+  # Allowed values: Auto, Recreate, Initial, Off
+  updateMode: Auto
   proxy:
+    # mode controls whether VPA is active for proxy containers. Allowed values: Auto, Off
+    mode: Auto
+    # controlledValues specifies which resource values are controlled. Allowed values: RequestsAndLimits, RequestsOnly
+    controlledValues: RequestsAndLimits
     minAllowed:
       cpu: 250m
       memory: 256Mi
+    # maxAllowed: {}
   controller:
+    # mode controls whether VPA is active for the ingress controller container. Allowed values: Auto, Off
+    mode: Auto
+    # controlledValues specifies which resource values are controlled. Allowed values: RequestsAndLimits, RequestsOnly
+    controlledValues: RequestsAndLimits
     minAllowed:
       cpu: 100m
+    # maxAllowed: {}
 
 # Kong Pod Disruption Budget
 podDisruptionBudget:

--- a/sync/patches/values-schema/values.yaml.patch
+++ b/sync/patches/values-schema/values.yaml.patch
@@ -209,7 +209,7 @@ index bdecdf6..489441b 100644
  
  # Annotations to be added to Kong deployment
  deploymentAnnotations: {}
-@@ -979,11 +1023,24 @@ autoscaling:
+@@ -979,11 +1023,37 @@ autoscaling:
            type: Utilization
            averageUtilization: 80
  
@@ -218,13 +218,26 @@ index bdecdf6..489441b 100644
 +# "resources" and, if using the controller, "ingressController.resources" in values.yaml
 +verticalPodAutoscaler:
 +  enabled: false
++  # updateMode controls when VPA applies resource recommendations.
++  # Allowed values: Auto, Recreate, Initial, Off
++  updateMode: Auto
 +  proxy:
++    # mode controls whether VPA is active for proxy containers. Allowed values: Auto, Off
++    mode: Auto
++    # controlledValues specifies which resource values are controlled. Allowed values: RequestsAndLimits, RequestsOnly
++    controlledValues: RequestsAndLimits
 +    minAllowed:
 +      cpu: 250m
 +      memory: 256Mi
++    # maxAllowed: {}
 +  controller:
++    # mode controls whether VPA is active for the ingress controller container. Allowed values: Auto, Off
++    mode: Auto
++    # controlledValues specifies which resource values are controlled. Allowed values: RequestsAndLimits, RequestsOnly
++    controlledValues: RequestsAndLimits
 +    minAllowed:
 +      cpu: 100m
++    # maxAllowed: {}
 +
  # Kong Pod Disruption Budget
  podDisruptionBudget:
@@ -236,7 +249,7 @@ index bdecdf6..489441b 100644
    # minAvailable: "50%"
    unhealthyPodEvictionPolicy: IfHealthyBudget
  
-@@ -1055,9 +1112,9 @@ serviceMonitor:
+@@ -1055,9 +1125,9 @@ serviceMonitor:
    # Specifies whether ServiceMonitor for Prometheus operator should be created
    # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
    # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
@@ -248,7 +261,7 @@ index bdecdf6..489441b 100644
    # Specifies namespace, where ServiceMonitor should be installed
    # namespace: monitoring
    # labels:
-@@ -1067,7 +1124,15 @@ serviceMonitor:
+@@ -1067,7 +1137,15 @@ serviceMonitor:
  
    # honorLabels: false
    # metricRelabelings: []
@@ -265,7 +278,7 @@ index bdecdf6..489441b 100644
  
  # -----------------------------------------------------------------------------
  # Kong Enterprise parameters
-@@ -1318,3 +1383,10 @@ extraObjects: []
+@@ -1318,3 +1396,10 @@ extraObjects: []
  #   config:
  #     per_consumer: false
  #   plugin: prometheus

--- a/sync/patches/values-schema/values.yaml.patch
+++ b/sync/patches/values-schema/values.yaml.patch
@@ -219,7 +219,7 @@ index bdecdf6..489441b 100644
 +verticalPodAutoscaler:
 +  enabled: false
 +  # updateMode controls when VPA applies resource recommendations.
-+  # Allowed values: Auto, Recreate, Initial, Off
++  # Allowed values: Off, Initial, Recreate, InPlaceOrRecreate, Auto
 +  updateMode: Auto
 +  proxy:
 +    # mode controls whether VPA is active for proxy containers. Allowed values: Auto, Off

--- a/sync/patches/vpa/vpa.yaml
+++ b/sync/patches/vpa/vpa.yaml
@@ -13,31 +13,43 @@ spec:
     containerPolicies:
     {{- if .Values.deployment.kong.enabled }}
     - containerName: proxy
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.proxy.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.proxy.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.proxy.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.proxy.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     - containerName: clear-stale-pid
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.proxy.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.proxy.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.proxy.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.proxy.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
     - containerName: wait-for-db
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.proxy.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.proxy.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.proxy.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.proxy.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- end }}
     {{- if .Values.ingressController.enabled }}
     - containerName: ingress-controller
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      controlledValues: {{ .Values.verticalPodAutoscaler.controller.controlledValues }}
+      mode: {{ .Values.verticalPodAutoscaler.controller.mode }}
       minAllowed: {{ toYaml .Values.verticalPodAutoscaler.controller.minAllowed | nindent 8 }}
+      {{- with .Values.verticalPodAutoscaler.controller.maxAllowed }}
+      maxAllowed: {{ toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
   targetRef:
     apiVersion: apps/v1
     kind: {{ ternary "DaemonSet" "Deployment" .Values.deployment.daemonset }}
     name: {{ template "kong.fullname" . }}
   updatePolicy:
-    updateMode: Auto
+    updateMode: {{ .Values.verticalPodAutoscaler.updateMode }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

<!--
Please update after a release:
- the version matrix in README.md
- the kong-gateway tag in tests/test-values-enterprise.yaml
-->

This PR...

## Checklist

- [ ] Automated test are working (for chart changes)
- [ ] Changelog entry has been added

### Manual tests on workload clusters

For plain installations (default values) and database mode (deploy `tests/manual/postgres.yaml`, then install with `tests/manual/values-database.yaml`), execute these tests. If you have additional configuration, make sure your existing deployments with custom values still work.

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
