### PR TITLE
Fix VPA updateMode to allow `off`, which is considered a boolean in yaml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix VPA updateMode to allow `off`, which is considered a boolean in yaml.
+
 ## [5.2.2] - 2026-03-24
 
 ### Changed

--- a/helm/kong-app/templates/vpa.yaml
+++ b/helm/kong-app/templates/vpa.yaml
@@ -50,6 +50,6 @@ spec:
     kind: {{ ternary "DaemonSet" "Deployment" .Values.deployment.daemonset }}
     name: {{ template "kong.fullname" . }}
   updatePolicy:
-    updateMode: {{ .Values.verticalPodAutoscaler.updateMode }}
+    updateMode: {{ .Values.verticalPodAutoscaler.updateMode | quote }}
 {{- end }}
 {{- end }}

--- a/sync/patches/vpa/vpa.yaml
+++ b/sync/patches/vpa/vpa.yaml
@@ -50,6 +50,6 @@ spec:
     kind: {{ ternary "DaemonSet" "Deployment" .Values.deployment.daemonset }}
     name: {{ template "kong.fullname" . }}
   updatePolicy:
-    updateMode: {{ .Values.verticalPodAutoscaler.updateMode }}
+    updateMode: {{ .Values.verticalPodAutoscaler.updateMode | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

<!--
Please update after a release:
- the version matrix in README.md
- the kong-gateway tag in tests/test-values-enterprise.yaml
-->

This PR...

## Checklist

- [ ] Automated test are working (for chart changes)
- [ ] Changelog entry has been added

### Manual tests on workload clusters

For plain installations (default values) and database mode (deploy `tests/manual/postgres.yaml`, then install with `tests/manual/values-database.yaml`), execute these tests. If you have additional configuration, make sure your existing deployments with custom values still work.

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
