### PR TITLE
chore: replace decommissioned giantswarmpublic.azurecr.io registry

### DIFF
--- a/helm/kong-app/Chart.lock
+++ b/helm/kong-app/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kubectl-apply-job
   repository: oci://gsoci.azurecr.io/charts/giantswarm
   version: 0.11.0
-digest: sha256:06e1f0899563c64bb2553ba50c0c31af4e6f8cf5cd76f94c988a8f8d8d97e36a
-generated: "2025-12-04T15:06:59.777080911Z"
+digest: sha256:2245186715e800f473b2bac5f23dfb264b45aa0f58e47c74742de33686609d20
+generated: "2026-06-25T09:51:39.599555419+02:00"

--- a/helm/kong-app/Chart.lock
+++ b/helm/kong-app/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.9.13
 - name: kubectl-apply-job
-  repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog
+  repository: oci://gsoci.azurecr.io/charts/giantswarm
   version: 0.11.0
 digest: sha256:06e1f0899563c64bb2553ba50c0c31af4e6f8cf5cd76f94c988a8f8d8d97e36a
 generated: "2025-12-04T15:06:59.777080911Z"

--- a/helm/kong-app/Chart.yaml
+++ b/helm/kong-app/Chart.yaml
@@ -22,5 +22,5 @@ dependencies:
     condition: postgresql.enabled
   - name: kubectl-apply-job
     version: "0.11.0"
-    repository: oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog
+    repository: oci://gsoci.azurecr.io/charts/giantswarm
     condition: ingressController.enabled


### PR DESCRIPTION
The container registry `giantswarmpublic.azurecr.io` (which hosted Giant Swarm Helm chart catalogs) has been decommissioned. All chart catalogs are now consolidated onto `oci://gsoci.azurecr.io/charts/giantswarm/<chart>`.

This PR updates the `kubectl-apply-job` chart dependency so it resolves from `oci://gsoci.azurecr.io/charts/giantswarm` instead of the decommissioned `oci://giantswarmpublic.azurecr.io/giantswarm-playground-catalog`.

- `helm/kong-app/Chart.yaml`: updated the `kubectl-apply-job` dependency `repository`.
- `helm/kong-app/Chart.lock`: updated the `repository` line.

> [!WARNING]
> The `Chart.lock` digest could **not** be regenerated locally. Running `helm dependency update` failed to pull `kubectl-apply-job` from `gsoci.azurecr.io` with a `401 Unauthorized` (no registry auth available in this environment), so only the `repository:` line was updated and the existing `digest:` was left unchanged. **`helm dep update` needs to be run in CI or locally (with gsoci access) to regenerate a fresh digest.**

## Checklist

- [ ] Automated test are working (for chart changes)
- [ ] Changelog entry has been added

### Manual tests on workload clusters

For plain installations (default values) and database mode (deploy `tests/manual/postgres.yaml`, then install with `tests/manual/values-database.yaml`), execute these tests. If you have additional configuration, make sure your existing deployments with custom values still work.

- [ ] Upgrade from previous version works
- [ ] Existing Ingress resources are reconciled correctly (change domain, see if its available)
- [ ] Fresh install works
- [ ] Fresh Ingress resources are reconciled correctly
